### PR TITLE
Adding a Swift MessageFactory for performance

### DIFF
--- a/SwiftMailer/MessageFactory.php
+++ b/SwiftMailer/MessageFactory.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MonologBundle\SwiftMailer;
+
+/**
+ * Helps create Swift_Message objects, lazily
+ *
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+class MessageFactory
+{
+    private $mailer;
+
+    private $fromEmail;
+
+    private $toEmail;
+
+    private $subject;
+
+    private $contentType;
+
+    public function __construct(\Swift_Mailer $mailer, $fromEmail, $toEmail, $subject, $contentType = null)
+    {
+        $this->mailer = $mailer;
+        $this->fromEmail = $fromEmail;
+        $this->toEmail = $toEmail;
+        $this->subject = $subject;
+        $this->contentType = $contentType;
+    }
+
+    /**
+     * Creates a Swift_Message template that will be used to send the log message
+     *
+     * @param string $content formatted email body to be sent
+     * @param array  $records Log records that formed the content
+     * @return \Swift_Message
+     */
+    public function createMessage($content, array $records)
+    {
+        /** @var \Swift_Message $message */
+        $message = $this->mailer->createMessage();
+        $message->setTo($this->toEmail);
+        $message->setFrom($this->fromEmail);
+        $message->setSubject($this->subject);
+
+        if ($this->contentType) {
+            $message->setContentType($this->contentType);
+        }
+
+        return $message;
+    }
+}

--- a/Tests/DependencyInjection/FixtureMonologExtensionTest.php
+++ b/Tests/DependencyInjection/FixtureMonologExtensionTest.php
@@ -140,22 +140,26 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
     {
         $container = $this->getContainer('single_email_recipient');
 
-        $this->assertSame(array(
-            array('setFrom', array('error@example.com')),
-            array('setTo', array(array('error@example.com'))),
-            array('setSubject', array('An Error Occurred!')),
-        ), $container->getDefinition('monolog.handler.swift.mail_prototype')->getMethodCalls());
+        $this->assertEquals(array(
+            new Reference('mailer'),
+            'error@example.com', // from
+            array('error@example.com'), // to
+            'An Error Occurred!', // subject
+            null,
+        ), $container->getDefinition('monolog.handler.swift.mail_message_factory')->getArguments());
     }
 
     public function testMultipleEmailRecipients()
     {
         $container = $this->getContainer('multiple_email_recipients');
 
-        $this->assertSame(array(
-            array('setFrom', array('error@example.com')),
-            array('setTo', array(array('dev1@example.com', 'dev2@example.com'))),
-            array('setSubject', array('An Error Occurred!')),
-        ), $container->getDefinition('monolog.handler.swift.mail_prototype')->getMethodCalls());
+        $this->assertEquals (array(
+            new Reference('mailer'),
+            'error@example.com',
+            array('dev1@example.com', 'dev2@example.com'),
+            'An Error Occurred!',
+            null
+        ), $container->getDefinition('monolog.handler.swift.mail_message_factory')->getArguments());
     }
 
     public function testChannelParametersResolved()


### PR DESCRIPTION
Hiya guys!

Blackfire comparison: https://blackfire.io/profiles/compare/0ab8c333-3272-4af0-8b57-ff0b4e3478de/graph

Prior to this, in order for the main logger to be instantiated, if you had a swiftmailer handler, ultimately a single Swift_Message would be created, even if you didn't need it. That sounds minor, but due to Swift's
autoloading, it required quite a few extra classes, which added a small amount of extra memory (~1MB) and extra CPU due to the auto-loader (~10-20ms).

This keeps BC, only renaming a service that was private anyways.

Cheers!