### PR TITLE
Don't trigger a deprecation warning for Reference::isStrict()

### DIFF
--- a/DependencyInjection/Compiler/LoggerChannelPass.php
+++ b/DependencyInjection/Compiler/LoggerChannelPass.php
@@ -125,7 +125,7 @@ class LoggerChannelPass implements CompilerPassInterface
     {
         if (method_exists($reference, 'isStrict')) {
             // Stay compatible with Symfony 2
-            return new Reference($serviceId, $reference->getInvalidBehavior(), $reference->isStrict());
+            return new Reference($serviceId, $reference->getInvalidBehavior(), $reference->isStrict(false));
         }
 
         return new Reference($serviceId, $reference->getInvalidBehavior());


### PR DESCRIPTION
As @Tobion pointed out in a comment to my merged PR #138, the `LoggerChannelPass` still triggers deprecation warnings with Symfony 2.8. When writing my patch, I was not aware that I could suppress the warning by passing `false` as parameter to `Reference::isStrict()`.

I think, suppressing the warning is the way to go because we already took care of the deprecation in #138: Once `isStrict()` is gone, it won't be called anymore. But as long as it's still there, other bundles might be using that functionality, so imho there's no way around calling `isStrict()` without potentially breaking stuff.