### PR TITLE
Added missing ignore_error option to Configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -419,6 +419,7 @@ class Configuration implements ConfigurationInterface
                             ->end() // elasticsearch
                             ->scalarNode('index')->defaultValue('monolog')->end() // elasticsearch
                             ->scalarNode('document_type')->defaultValue('logs')->end() // elasticsearch
+                            ->scalarNode('ignore_error')->defaultValue(false)->end() // elasticsearch
                             ->arrayNode('config')
                                 ->canBeUnset()
                                 ->prototype('scalar')->end()

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -254,6 +254,7 @@ class MonologExtension extends Extension
                 array(
                     'index' => $handler['index'],
                     'type' => $handler['document_type'],
+                    'ignore_error' => $handler['ignore_error']
                 ),
                 $handler['level'],
                 $handler['bubble'],

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -217,6 +217,31 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('mailer', $config['handlers']['swift']['mailer']);
     }
 
+    public function testWithElasticsearchHandler() {
+        $configs = array(
+            array(
+                'handlers' => array(
+                    'elasticsearch' => array(
+                        'type' => 'elasticsearch',
+                        'elasticsearch' => array(
+                            'id' => 'elastica.client'
+                        ),
+                        'index' => 'my-index',
+                        'document_type' => 'my-record',
+                        'ignore_error' => true
+                    )
+                )
+            )
+        );
+
+        $config = $this->process($configs);
+
+        $this->assertEquals(true, $config['handlers']['elasticsearch']['ignore_error']);
+        $this->assertEquals('my-record', $config['handlers']['elasticsearch']['document_type']);
+        $this->assertEquals('my-index', $config['handlers']['elasticsearch']['index']);
+
+    }
+
     public function testWithConsoleHandler()
     {
         $configs = array(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #144
| License       | n/a


The `ignore_error` option was missing in the Bundle's `Configuration.php`