### PR TITLE
Expose all of HipChat's parameters

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -179,6 +179,8 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
  *   - [bubble]: bool, defaults to true
  *   - [use_ssl]: bool, defaults to true
  *   - [message_format]: text or html, defaults to text
+ *   - [host]: defaults to "api.hipchat.com"
+ *   - [api_version]: defaults to "v1"
  *
  * - slack:
  *   - token: slack api token
@@ -330,6 +332,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('exchange_name')->defaultValue('log')->end() // amqp
                             ->scalarNode('room')->end() // hipchat
                             ->scalarNode('message_format')->defaultValue('text')->end() // hipchat
+                            ->scalarNode('api_version')->defaultNull()->end() // hipchat
                             ->scalarNode('channel')->end() // slack
                             ->scalarNode('bot_name')->defaultValue('Monolog')->end() // slack
                             ->scalarNode('use_attachment')->defaultTrue()->end() // slack
@@ -350,7 +353,7 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                             ->scalarNode('title')->defaultNull()->end() // pushover
-                            ->scalarNode('host')->end() // syslogudp
+                            ->scalarNode('host')->defaultNull()->end() // syslogudp & hipchat
                             ->scalarNode('port')->defaultValue(514)->end() // syslogudp
                             ->arrayNode('publisher')
                                 ->canBeUnset()
@@ -652,6 +655,10 @@ class Configuration implements ConfigurationInterface
                         ->validate()
                             ->ifTrue(function ($v) { return 'hipchat' === $v['type'] && !in_array($v['message_format'], array('text', 'html')); })
                             ->thenInvalid('The message_format has to be "text" or "html" in a HipChatHandler')
+                        ->end()
+                        ->validate()
+                            ->ifTrue(function ($v) { return 'hipchat' === $v['type'] && null !== $v['api_version'] && !in_array($v['api_version'], array('v1', 'v2'), true); })
+                            ->thenInvalid('The api_version has to be "v1" or "v2" in a HipChatHandler')
                         ->end()
                         ->validate()
                             ->ifTrue(function ($v) { return 'slack' === $v['type'] && (empty($v['token']) || empty($v['channel'])); })

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -468,6 +468,8 @@ class MonologExtension extends Extension
                 $handler['bubble'],
                 $handler['use_ssl'],
                 $handler['message_format'],
+                !empty($handler['host']) ? $handler['host'] : 'api.hipchat.com',
+                !empty($handler['api_version']) ? $handler['api_version'] : 'v1',
             ));
             break;
 

--- a/Resources/config/schema/monolog-1.0.xsd
+++ b/Resources/config/schema/monolog-1.0.xsd
@@ -68,6 +68,7 @@
         <xsd:attribute name="file-permission" type="xsd:string" />
         <xsd:attribute name="index" type="xsd:string" />
         <xsd:attribute name="document_type" type="xsd:string" />
+        <xsd:attribute name="api_version" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:simpleType name="level">


### PR DESCRIPTION
There are two currently unexposed parameters of the [`HipChatHandler`](https://github.com/Seldaek/monolog/blob/f86e643a5814f90724ddd09b99304611633f92e0/src/Monolog/Handler/HipChatHandler.php#L98): 

* `$host` which is required to support [HipChat Server](https://www.hipchat.com/server)
* `$version` the API version, where you might want to switch to the v2 api

These two options are currently not exposed in the configuration.

I wasn't sure on how to add these options and especially unsure about how to define a fallback in the configuration, if the option is used by multiple handlers (like `host`). The current way is to just pass `null` in these parameters and set the defaults in the handler directly:

```php
public function __construct($token, $room, $name = 'Monolog', $notify = false, $level = Logger::CRITICAL, $bubble = true, $useSSL = true, $format = 'text', $host = 'api.hipchat.com', $version = self::API_V1)
{
    if (null === $host)
    {
        $host = 'api.hipchat.com';
    }

    if (null === $version)
    {
        $version = self::API_V1;
    }

    // ...
}
```

Please tell me if whether this is ok or how I can implement it in a better way.
If the proposed implementation is ok, I would send a PR to Monolog for the changes mentioned above.

This would however be a soft BC break (in the sense that the `monolog-bundle` then requires the newest version of `monolog`).