### PR TITLE
Improve Documentation

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -184,7 +184,7 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
  *
  * - slack:
  *   - token: slack api token
- *   - channel: channel name
+ *   - channel: channel name (with starting #)
  *   - [bot_name]: defaults to Monolog
  *   - [icon_emoji]: defaults to null
  *   - [use_attachment]: bool, defaults to true


### PR DESCRIPTION
Add a small notice to the slack configuration that the channel name have to contain the '#'.