### PR TITLE
Add include_stacktraces configuration option to handlers

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -292,6 +292,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('priority')->defaultValue(0)->end()
                             ->scalarNode('level')->defaultValue('DEBUG')->end()
                             ->booleanNode('bubble')->defaultTrue()->end()
+                            ->booleanNode('include_stacktraces')->defaultFalse()->end()
                             ->scalarNode('path')->defaultValue('%kernel.logs_dir%/%kernel.environment%.log')->end() // stream and rotating
                             ->scalarNode('file_permission')  // stream and rotating
                                 ->defaultNull()

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -130,6 +130,10 @@ class MonologExtension extends Extension
         $definition = new Definition(sprintf('%%monolog.handler.%s.class%%', $handler['type']));
         $handler['level'] = $this->levelToMonologConst($handler['level']);
 
+        if ($handler['include_stacktraces']) {
+            $definition->setConfigurator(array('Symfony\\Bundle\\MonologBundle\\MonologBundle', 'includeStacktraces'));
+        }
+
         switch ($handler['type']) {
         case 'service':
             $container->setAlias($handlerId, $handler['id']);

--- a/MonologBundle.php
+++ b/MonologBundle.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bundle\MonologBundle;
 
+use Monolog\Formatter\LineFormatter;
+use Monolog\Handler\HandlerInterface;
 use Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\AddSwiftMailerTransportPass;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -33,5 +35,16 @@ class MonologBundle extends Bundle
         $container->addCompilerPass(new DebugHandlerPass($channelPass));
         $container->addCompilerPass(new AddProcessorsPass());
         $container->addCompilerPass(new AddSwiftMailerTransportPass());
+    }
+
+    /**
+     * @internal
+     */
+    public static function includeStacktraces(HandlerInterface $handler)
+    {
+        $formatter = $handler->getFormatter();
+        if ($formatter instanceof LineFormatter) {
+            $formatter->includeStacktraces();
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/dependency-injection": "~2.3|~3.0",
         "symfony/config": "~2.3|~3.0",
         "symfony/http-kernel": "~2.3|~3.0",
-        "monolog/monolog": "~1.8"
+        "monolog/monolog": "~1.12"
     },
     "require-dev": {
         "symfony/yaml": "~2.3|~3.0",


### PR DESCRIPTION
Fixes https://github.com/symfony/symfony/pull/17168
Allows people to add stacktraces to their log when they want to.