### PR TITLE
Add a nested option on handler config definition

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -592,6 +592,7 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                             ->scalarNode('formatter')->end()
+                            ->booleanNode('nested')->defaultFalse()->end()
                         ->end()
                         ->validate()
                             ->ifTrue(function ($v) { return 'service' === $v['type'] && !empty($v['formatter']); })

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -36,6 +36,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('foobar', $config['handlers']);
         $this->assertEquals('stream', $config['handlers']['foobar']['type']);
         $this->assertEquals('/foo/bar', $config['handlers']['foobar']['path']);
+        $this->assertFalse($config['handlers']['foobar']['nested']);
     }
 
     public function provideProcessStringChannels()
@@ -319,6 +320,20 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame(0666, $config['handlers']['foo']['file_permission']);
         $this->assertSame(0777, $config['handlers']['bar']['file_permission']);
+    }
+
+    public function testWithNestedHandler()
+    {
+        $configs = array(
+            array(
+                'handlers' => array('foobar' => array('type' => 'stream', 'path' => '/foo/bar', 'nested' => true))
+            )
+        );
+
+        $config = $this->process($configs);
+
+
+        $this->assertTrue($config['handlers']['foobar']['nested']);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Marked nested handlers with not be pushed to the logger handler array.
This options may be usefull when using custom handler (as service type handlers) which rely on a sub handler defined in the monolog-bundle configuration.
Marking this subhandler as nested avoid monolog to directly call it.

### Sample Usage

```yaml
monolog:
    handlers:
        foo:
            type: service
            id: my_site.custom_log_handler
        bar:
            type:  stream
            path:  "%kernel.logs_dir%/%kernel.environment%-bar.log"
            level: debug
            nested: true

services:
    my_site.custom_log_handler:
        class: AppBundle\Logger\CustomHandler
        arguments:
            - "@monolog.handler.bar"
```