### PR TITLE
bump Monolog versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/dependency-injection": "~2.3|~3.0",
         "symfony/config": "~2.3|~3.0",
         "symfony/http-kernel": "~2.3|~3.0",
-        "monolog/monolog": "~1.12"
+        "monolog/monolog": "~1.18"
     },
     "require-dev": {
         "symfony/yaml": "~2.3|~3.0",


### PR DESCRIPTION
The `useMicrosecondTimestamps()` method was introduced in Monolog
1.18.0.