### PR TITLE
remove class parameters

### DIFF
--- a/DependencyInjection/Compiler/DebugHandlerPass.php
+++ b/DependencyInjection/Compiler/DebugHandlerPass.php
@@ -47,7 +47,7 @@ class DebugHandlerPass implements CompilerPassInterface
             return;
         }
 
-        $debugHandler = new Definition('%monolog.handler.debug.class%', array(Logger::DEBUG, true));
+        $debugHandler = new Definition('Symfony\Bridge\Monolog\Handler\DebugHandler', array(Logger::DEBUG, true));
         $container->setDefinition('monolog.handler.debug', $debugHandler);
 
         foreach ($this->channelPass->getChannels() as $channel) {

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -130,8 +130,8 @@ class MonologExtension extends Extension
     private function buildHandler(ContainerBuilder $container, $name, array $handler)
     {
         $handlerId = $this->getHandlerId($name);
-        $defaultDefinition = $container->getDefinition(sprintf('monolog.handler.%s', $handler['type']));
-        $definition = new Definition($defaultDefinition->getClass());
+        $definition = new Definition($this->getHandlerClassByType($handler['type']));
+
         $handler['level'] = $this->levelToMonologConst($handler['level']);
 
         if ($handler['include_stacktraces']) {
@@ -694,4 +694,52 @@ class MonologExtension extends Extension
     {
         return sprintf('monolog.handler.%s', $name);
     }
+
+    private function getHandlerClassByType($handlerType)
+    {
+        $typeToClassMapping = array(
+            'stream' => 'Monolog\Handler\StreamHandler',
+            'console' => 'Symfony\Bridge\Monolog\Handler\ConsoleHandler',
+            'group' => 'Monolog\Handler\GroupHandler',
+            'buffer' => 'Monolog\Handler\BufferHandler',
+            'deduplication' => 'Monolog\Handler\DeduplicationHandler',
+            'rotating_file' => 'Monolog\Handler\RotatingFileHandler',
+            'syslog' => 'Monolog\Handler\SyslogHandler',
+            'syslogudp' => 'Monolog\Handler\SyslogUdpHandler',
+            'null' => 'Monolog\Handler\NullHandler',
+            'test' => 'Monolog\Handler\TestHandler',
+            'gelf' => 'Monolog\Handler\GelfHandler',
+            'rollbar' => 'Monolog\Handler\RollbarHandler',
+            'flowdock' => 'Monolog\Handler\FlowdockHandler',
+            'browser_console' => 'Monolog\Handler\BrowserConsoleHandler',
+            'firephp' => 'Symfony\Bridge\Monolog\Handler\FirePHPHandler',
+            'chromephp' => 'Symfony\Bridge\Monolog\Handler\ChromePhpHandler',
+            'debug' => 'Symfony\Bridge\Monolog\Handler\DebugHandler',
+            'swift_mailer' => 'Symfony\Bridge\Monolog\Handler\SwiftMailerHandler',
+            'native_mailer' => 'Monolog\Handler\NativeMailerHandler',
+            'socket' => 'Monolog\Handler\SocketHandler',
+            'pushover' => 'Monolog\Handler\PushoverHandler',
+            'raven' => 'Monolog\Handler\RavenHandler',
+            'newrelic' => 'Monolog\Handler\NewRelicHandler',
+            'hipchat' => 'Monolog\Handler\HipChatHandler',
+            'slack' => 'Monolog\Handler\SlackHandler',
+            'cube' => 'Monolog\Handler\CubeHandler',
+            'amqp' => 'Monolog\Handler\AmqpHandler',
+            'error_log' => 'Monolog\Handler\ErrorLogHandler',
+            'loggly' => 'Monolog\Handler\LogglyHandler',
+            'logentries' => 'Monolog\Handler\LogEntriesHandler',
+            'whatfailuregroup' => 'Monolog\Handler\WhatFailureGroupHandler',
+            'fingers_crossed' => 'Monolog\Handler\FingersCrossedHandler',
+            'filter' => 'Monolog\Handler\FilterHandler',
+            'mongo' => 'Monolog\Handler\MongoDBHandler',
+            'elasticsearch' => 'Monolog\Handler\ElasticSearchHandler',
+        );
+
+        if (!isset($typeToClassMapping[$handlerType])) {
+            throw new \InvalidArgumentException(sprintf('There is no handler class defined for handler "%s".', $handlerType));
+        }
+
+        return $typeToClassMapping[$handlerType];
+    }
+
 }

--- a/Resources/config/monolog.xml
+++ b/Resources/config/monolog.xml
@@ -4,53 +4,6 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="monolog.logger.class">Symfony\Bridge\Monolog\Logger</parameter>
-        <parameter key="monolog.gelf.publisher.class">Gelf\MessagePublisher</parameter>
-        <parameter key="monolog.gelfphp.publisher.class">Gelf\Publisher</parameter>
-        <parameter key="monolog.handler.stream.class">Monolog\Handler\StreamHandler</parameter>
-        <parameter key="monolog.handler.console.class">Symfony\Bridge\Monolog\Handler\ConsoleHandler</parameter>
-        <parameter key="monolog.handler.group.class">Monolog\Handler\GroupHandler</parameter>
-        <parameter key="monolog.handler.buffer.class">Monolog\Handler\BufferHandler</parameter>
-        <parameter key="monolog.handler.deduplication.class">Monolog\Handler\DeduplicationHandler</parameter>
-        <parameter key="monolog.handler.rotating_file.class">Monolog\Handler\RotatingFileHandler</parameter>
-        <parameter key="monolog.handler.syslog.class">Monolog\Handler\SyslogHandler</parameter>
-        <parameter key="monolog.handler.syslogudp.class">Monolog\Handler\SyslogUdpHandler</parameter>
-        <parameter key="monolog.handler.null.class">Monolog\Handler\NullHandler</parameter>
-        <parameter key="monolog.handler.test.class">Monolog\Handler\TestHandler</parameter>
-        <parameter key="monolog.handler.gelf.class">Monolog\Handler\GelfHandler</parameter>
-        <parameter key="monolog.handler.rollbar.class">Monolog\Handler\RollbarHandler</parameter>
-        <parameter key="monolog.handler.flowdock.class">Monolog\Handler\FlowdockHandler</parameter>
-        <parameter key="monolog.handler.browser_console.class">Monolog\Handler\BrowserConsoleHandler</parameter>
-        <parameter key="monolog.handler.firephp.class">Symfony\Bridge\Monolog\Handler\FirePHPHandler</parameter>
-        <parameter key="monolog.handler.chromephp.class">Symfony\Bridge\Monolog\Handler\ChromePhpHandler</parameter>
-        <parameter key="monolog.handler.debug.class">Symfony\Bridge\Monolog\Handler\DebugHandler</parameter>
-        <parameter key="monolog.handler.swift_mailer.class">Symfony\Bridge\Monolog\Handler\SwiftMailerHandler</parameter>
-        <parameter key="monolog.handler.native_mailer.class">Monolog\Handler\NativeMailerHandler</parameter>
-        <parameter key="monolog.handler.socket.class">Monolog\Handler\SocketHandler</parameter>
-        <parameter key="monolog.handler.pushover.class">Monolog\Handler\PushoverHandler</parameter>
-        <parameter key="monolog.handler.raven.class">Monolog\Handler\RavenHandler</parameter>
-        <parameter key="monolog.handler.newrelic.class">Monolog\Handler\NewRelicHandler</parameter>
-        <parameter key="monolog.handler.hipchat.class">Monolog\Handler\HipChatHandler</parameter>
-        <parameter key="monolog.handler.slack.class">Monolog\Handler\SlackHandler</parameter>
-        <parameter key="monolog.handler.cube.class">Monolog\Handler\CubeHandler</parameter>
-        <parameter key="monolog.handler.amqp.class">Monolog\Handler\AmqpHandler</parameter>
-        <parameter key="monolog.handler.error_log.class">Monolog\Handler\ErrorLogHandler</parameter>
-        <parameter key="monolog.handler.loggly.class">Monolog\Handler\LogglyHandler</parameter>
-        <parameter key="monolog.handler.logentries.class">Monolog\Handler\LogEntriesHandler</parameter>
-        <parameter key="monolog.handler.whatfailuregroup.class">Monolog\Handler\WhatFailureGroupHandler</parameter>
-        <parameter key="monolog.activation_strategy.not_found.class">Symfony\Bundle\MonologBundle\NotFoundActivationStrategy</parameter>
-
-        <parameter key="monolog.handler.fingers_crossed.class">Monolog\Handler\FingersCrossedHandler</parameter>
-        <parameter key="monolog.handler.fingers_crossed.error_level_activation_strategy.class">Monolog\Handler\FingersCrossed\ErrorLevelActivationStrategy</parameter>
-        <parameter key="monolog.handler.filter.class">Monolog\Handler\FilterHandler</parameter>
-        <parameter key="monolog.handler.mongo.class">Monolog\Handler\MongoDBHandler</parameter>
-        <parameter key="monolog.mongo.client.class">MongoClient</parameter>
-
-        <parameter key="monolog.handler.elasticsearch.class">Monolog\Handler\ElasticSearchHandler</parameter>
-        <parameter key="monolog.elastica.client.class">Elastica\Client</parameter>
-    </parameters>
-
     <services>
         <service id="monolog.logger" parent="monolog.logger_prototype" public="false">
             <argument index="0">app</argument>
@@ -61,9 +14,52 @@
 
         <service id="logger" alias="monolog.logger" />
 
-        <service id="monolog.logger_prototype" class="%monolog.logger.class%" abstract="true">
+        <service id="monolog.logger_prototype" class="Symfony\Bridge\Monolog\Logger" abstract="true">
             <argument /><!-- Channel -->
         </service>
+
+        <service id="monolog.gelf.publisher" class="Gelf\MessagePublisher"/>
+        <service id="monolog.gelfphp.publisher" class="Gelf\Publisher"/>
+        <service id="monolog.handler.stream" class="Monolog\Handler\StreamHandler"/>
+        <service id="monolog.handler.console" class="Symfony\Bridge\Monolog\Handler\ConsoleHandler"/>
+        <service id="monolog.handler.group" class="Monolog\Handler\GroupHandler"/>
+        <service id="monolog.handler.buffer" class="Monolog\Handler\BufferHandler"/>
+        <service id="monolog.handler.deduplication" class="Monolog\Handler\DeduplicationHandler"/>
+        <service id="monolog.handler.rotating_file" class="Monolog\Handler\RotatingFileHandler"/>
+        <service id="monolog.handler.syslog" class="Monolog\Handler\SyslogHandler"/>
+        <service id="monolog.handler.syslogudp" class="Monolog\Handler\SyslogUdpHandler"/>
+        <service id="monolog.handler.null" class="Monolog\Handler\NullHandler"/>
+        <service id="monolog.handler.test" class="Monolog\Handler\TestHandler"/>
+        <service id="monolog.handler.gelf" class="Monolog\Handler\GelfHandler"/>
+        <service id="monolog.handler.rollbar" class="Monolog\Handler\RollbarHandler"/>
+        <service id="monolog.handler.flowdock" class="Monolog\Handler\FlowdockHandler"/>
+        <service id="monolog.handler.browser_console" class="Monolog\Handler\BrowserConsoleHandler"/>
+        <service id="monolog.handler.firephp" class="Symfony\Bridge\Monolog\Handler\FirePHPHandler"/>
+        <service id="monolog.handler.chromephp" class="Symfony\Bridge\Monolog\Handler\ChromePhpHandler"/>
+        <service id="monolog.handler.debug" class="Symfony\Bridge\Monolog\Handler\DebugHandler"/>
+        <service id="monolog.handler.swift_mailer" class="Symfony\Bridge\Monolog\Handler\SwiftMailerHandler"/>
+        <service id="monolog.handler.native_mailer" class="Monolog\Handler\NativeMailerHandler"/>
+        <service id="monolog.handler.socket" class="Monolog\Handler\SocketHandler"/>
+        <service id="monolog.handler.pushover" class="Monolog\Handler\PushoverHandler"/>
+        <service id="monolog.handler.raven" class="Monolog\Handler\RavenHandler"/>
+        <service id="monolog.handler.newrelic" class="Monolog\Handler\NewRelicHandler"/>
+        <service id="monolog.handler.hipchat" class="Monolog\Handler\HipChatHandler"/>
+        <service id="monolog.handler.slack" class="Monolog\Handler\SlackHandler"/>
+        <service id="monolog.handler.cube" class="Monolog\Handler\CubeHandler"/>
+        <service id="monolog.handler.amqp" class="Monolog\Handler\AmqpHandler"/>
+        <service id="monolog.handler.error_log" class="Monolog\Handler\ErrorLogHandler"/>
+        <service id="monolog.handler.loggly" class="Monolog\Handler\LogglyHandler"/>
+        <service id="monolog.handler.logentries" class="Monolog\Handler\LogEntriesHandler"/>
+        <service id="monolog.handler.whatfailuregroup" class="Monolog\Handler\WhatFailureGroupHandler"/>
+        <service id="monolog.activation_strategy.not_found" class="Symfony\Bundle\MonologBundle\NotFoundActivationStrategy"/>
+
+        <service id="monolog.handler.fingers_crossed" class="Monolog\Handler\FingersCrossedHandler"/>
+        <service id="monolog.handler.fingers_crossed.error_level_activation_strategy" class="Monolog\Handler\FingersCrossed\ErrorLevelActivationStrategy"/>
+        <service id="monolog.handler.filter" class="Monolog\Handler\FilterHandler"/>
+        <service id="monolog.handler.mongo" class="Monolog\Handler\MongoDBHandler"/>
+        <service id="monolog.mongo.client" class="MongoClient"/>
+
+        <service id="monolog.handler.elasticsearch" class="Monolog\Handler\ElasticSearchHandler"/>
 
         <!-- Formatters -->
         <service id="monolog.formatter.chrome_php" class="Monolog\Formatter\ChromePHPFormatter" public="false" />

--- a/Resources/config/monolog.xml
+++ b/Resources/config/monolog.xml
@@ -18,48 +18,8 @@
             <argument /><!-- Channel -->
         </service>
 
-        <service id="monolog.gelf.publisher" class="Gelf\MessagePublisher"/>
-        <service id="monolog.gelfphp.publisher" class="Gelf\Publisher"/>
-        <service id="monolog.handler.stream" class="Monolog\Handler\StreamHandler"/>
-        <service id="monolog.handler.console" class="Symfony\Bridge\Monolog\Handler\ConsoleHandler"/>
-        <service id="monolog.handler.group" class="Monolog\Handler\GroupHandler"/>
-        <service id="monolog.handler.buffer" class="Monolog\Handler\BufferHandler"/>
-        <service id="monolog.handler.deduplication" class="Monolog\Handler\DeduplicationHandler"/>
-        <service id="monolog.handler.rotating_file" class="Monolog\Handler\RotatingFileHandler"/>
-        <service id="monolog.handler.syslog" class="Monolog\Handler\SyslogHandler"/>
-        <service id="monolog.handler.syslogudp" class="Monolog\Handler\SyslogUdpHandler"/>
-        <service id="monolog.handler.null" class="Monolog\Handler\NullHandler"/>
-        <service id="monolog.handler.test" class="Monolog\Handler\TestHandler"/>
-        <service id="monolog.handler.gelf" class="Monolog\Handler\GelfHandler"/>
-        <service id="monolog.handler.rollbar" class="Monolog\Handler\RollbarHandler"/>
-        <service id="monolog.handler.flowdock" class="Monolog\Handler\FlowdockHandler"/>
-        <service id="monolog.handler.browser_console" class="Monolog\Handler\BrowserConsoleHandler"/>
-        <service id="monolog.handler.firephp" class="Symfony\Bridge\Monolog\Handler\FirePHPHandler"/>
-        <service id="monolog.handler.chromephp" class="Symfony\Bridge\Monolog\Handler\ChromePhpHandler"/>
-        <service id="monolog.handler.debug" class="Symfony\Bridge\Monolog\Handler\DebugHandler"/>
-        <service id="monolog.handler.swift_mailer" class="Symfony\Bridge\Monolog\Handler\SwiftMailerHandler"/>
-        <service id="monolog.handler.native_mailer" class="Monolog\Handler\NativeMailerHandler"/>
-        <service id="monolog.handler.socket" class="Monolog\Handler\SocketHandler"/>
-        <service id="monolog.handler.pushover" class="Monolog\Handler\PushoverHandler"/>
-        <service id="monolog.handler.raven" class="Monolog\Handler\RavenHandler"/>
-        <service id="monolog.handler.newrelic" class="Monolog\Handler\NewRelicHandler"/>
-        <service id="monolog.handler.hipchat" class="Monolog\Handler\HipChatHandler"/>
-        <service id="monolog.handler.slack" class="Monolog\Handler\SlackHandler"/>
-        <service id="monolog.handler.cube" class="Monolog\Handler\CubeHandler"/>
-        <service id="monolog.handler.amqp" class="Monolog\Handler\AmqpHandler"/>
-        <service id="monolog.handler.error_log" class="Monolog\Handler\ErrorLogHandler"/>
-        <service id="monolog.handler.loggly" class="Monolog\Handler\LogglyHandler"/>
-        <service id="monolog.handler.logentries" class="Monolog\Handler\LogEntriesHandler"/>
-        <service id="monolog.handler.whatfailuregroup" class="Monolog\Handler\WhatFailureGroupHandler"/>
         <service id="monolog.activation_strategy.not_found" class="Symfony\Bundle\MonologBundle\NotFoundActivationStrategy"/>
-
-        <service id="monolog.handler.fingers_crossed" class="Monolog\Handler\FingersCrossedHandler"/>
         <service id="monolog.handler.fingers_crossed.error_level_activation_strategy" class="Monolog\Handler\FingersCrossed\ErrorLevelActivationStrategy"/>
-        <service id="monolog.handler.filter" class="Monolog\Handler\FilterHandler"/>
-        <service id="monolog.handler.mongo" class="Monolog\Handler\MongoDBHandler"/>
-        <service id="monolog.mongo.client" class="MongoClient"/>
-
-        <service id="monolog.handler.elasticsearch" class="Monolog\Handler\ElasticSearchHandler"/>
 
         <!-- Formatters -->
         <service id="monolog.formatter.chrome_php" class="Monolog\Formatter\ChromePHPFormatter" public="false" />

--- a/Tests/DependencyInjection/FixtureMonologExtensionTest.php
+++ b/Tests/DependencyInjection/FixtureMonologExtensionTest.php
@@ -35,15 +35,15 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
         $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', array('%monolog.use_microseconds%'));
 
         $handler = $container->getDefinition('monolog.handler.custom');
-        $this->assertDICDefinitionClass($handler, '%monolog.handler.stream.class%');
+        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
         $this->assertDICConstructorArguments($handler, array('/tmp/symfony.log', \Monolog\Logger::ERROR, false, 0666));
 
         $handler = $container->getDefinition('monolog.handler.main');
-        $this->assertDICDefinitionClass($handler, '%monolog.handler.fingers_crossed.class%');
+        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\FingersCrossedHandler');
         $this->assertDICConstructorArguments($handler, array(new Reference('monolog.handler.nested'), \Monolog\Logger::ERROR, 0, true, true, \Monolog\Logger::NOTICE));
 
         $handler = $container->getDefinition('monolog.handler.filtered');
-        $this->assertDICDefinitionClass($handler, '%monolog.handler.filter.class%');
+        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\FilterHandler');
         $this->assertDICConstructorArguments($handler, array(new Reference('monolog.handler.nested2'), array(\Monolog\Logger::WARNING, \Monolog\Logger::ERROR), \Monolog\Logger::EMERGENCY, true));
     }
 
@@ -63,11 +63,11 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
         $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', array('%monolog.use_microseconds%'));
 
         $handler = $container->getDefinition('monolog.handler.custom');
-        $this->assertDICDefinitionClass($handler, '%monolog.handler.stream.class%');
+        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
         $this->assertDICConstructorArguments($handler, array('/tmp/symfony.log', \Monolog\Logger::WARNING, true, null));
 
         $handler = $container->getDefinition('monolog.handler.main');
-        $this->assertDICDefinitionClass($handler, '%monolog.handler.fingers_crossed.class%');
+        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\FingersCrossedHandler');
         $this->assertDICConstructorArguments($handler, array(new Reference('monolog.handler.nested'), \Monolog\Logger::ERROR, 0, true, true, null));
     }
 
@@ -89,7 +89,7 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
         $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', array('%monolog.use_microseconds%'));
 
         $handler = $container->getDefinition('monolog.handler.new');
-        $this->assertDICDefinitionClass($handler, '%monolog.handler.stream.class%');
+        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
         $this->assertDICConstructorArguments($handler, array('/tmp/monolog.log', \Monolog\Logger::ERROR, true, null));
     }
 
@@ -113,15 +113,15 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
         $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', array('%monolog.use_microseconds%'));
 
         $handler = $container->getDefinition('monolog.handler.main');
-        $this->assertDICDefinitionClass($handler, '%monolog.handler.buffer.class%');
+        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\BufferHandler');
         $this->assertDICConstructorArguments($handler, array(new Reference('monolog.handler.nested'), 0, \Monolog\Logger::INFO, true, false));
 
         $handler = $container->getDefinition('monolog.handler.first');
-        $this->assertDICDefinitionClass($handler, '%monolog.handler.rotating_file.class%');
+        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\RotatingFileHandler');
         $this->assertDICConstructorArguments($handler, array('/tmp/monolog.log', 0, \Monolog\Logger::ERROR, true, null));
 
         $handler = $container->getDefinition('monolog.handler.last');
-        $this->assertDICDefinitionClass($handler, '%monolog.handler.stream.class%');
+        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
         $this->assertDICConstructorArguments($handler, array('/tmp/last.log', \Monolog\Logger::ERROR, true, null));
     }
 

--- a/Tests/DependencyInjection/MonologExtensionTest.php
+++ b/Tests/DependencyInjection/MonologExtensionTest.php
@@ -31,7 +31,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', array(new Reference('monolog.handler.main')));
 
         $handler = $container->getDefinition('monolog.handler.main');
-        $this->assertDICDefinitionClass($handler, '%monolog.handler.stream.class%');
+        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
         $this->assertDICConstructorArguments($handler, array('%kernel.logs_dir%/%kernel.environment%.log', \Monolog\Logger::DEBUG, true, null));
     }
 
@@ -48,7 +48,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', array(new Reference('monolog.handler.custom')));
 
         $handler = $container->getDefinition('monolog.handler.custom');
-        $this->assertDICDefinitionClass($handler, '%monolog.handler.stream.class%');
+        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
         $this->assertDICConstructorArguments($handler, array('/tmp/symfony.log', \Monolog\Logger::ERROR, false, 0666));
     }
 
@@ -68,7 +68,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', array(new Reference('monolog.handler.custom')));
 
         $handler = $container->getDefinition('monolog.handler.custom');
-        $this->assertDICDefinitionClass($handler, '%monolog.handler.stream.class%');
+        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
         $this->assertDICConstructorArguments($handler, array('/tmp/symfony.log', \Monolog\Logger::ERROR, false, 0666));
     }
 
@@ -173,7 +173,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', array(new Reference('monolog.handler.main')));
 
         $handler = $container->getDefinition('monolog.handler.main');
-        $this->assertDICDefinitionClass($handler, '%monolog.handler.syslog.class%');
+        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\SyslogHandler');
         $this->assertDICConstructorArguments($handler, array(false, 'user', \Monolog\Logger::DEBUG, true, LOG_CONS));
     }
 
@@ -189,7 +189,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', array(new Reference('monolog.handler.main')));
 
         $handler = $container->getDefinition('monolog.handler.main');
-        $this->assertDICDefinitionClass($handler, '%monolog.handler.rollbar.class%');
+        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\RollbarHandler');
         $this->assertDICConstructorArguments($handler, array(new Reference('monolog.rollbar.notifier.1c8e6a67728dff6a209f828427128dd8b3c2b746'), \Monolog\Logger::DEBUG, true));
     }
 
@@ -205,7 +205,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', array(new Reference('monolog.handler.main')));
 
         $handler = $container->getDefinition('monolog.handler.main');
-        $this->assertDICDefinitionClass($handler, '%monolog.handler.rollbar.class%');
+        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\RollbarHandler');
         $this->assertDICConstructorArguments($handler, array(new Reference('my_rollbar_id'), \Monolog\Logger::DEBUG, true));
     }
 
@@ -230,7 +230,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', array(new Reference('monolog.handler.socket')));
 
         $handler = $container->getDefinition('monolog.handler.socket');
-        $this->assertDICDefinitionClass($handler, '%monolog.handler.socket.class%');
+        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\SocketHandler');
         $this->assertDICConstructorArguments($handler, array('localhost:50505', \Monolog\Logger::DEBUG, true));
         $this->assertDICDefinitionMethodCallAt(0, $handler, 'setTimeout', array('1'));
         $this->assertDICDefinitionMethodCallAt(1, $handler, 'setConnectionTimeout', array('0.6'));
@@ -265,7 +265,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         $this->assertTrue($container->hasDefinition('monolog.raven.client.'.sha1($dsn)));
 
         $handler = $container->getDefinition('monolog.handler.raven');
-        $this->assertDICDefinitionClass($handler, '%monolog.handler.raven.class%');
+        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\RavenHandler');
     }
 
     public function testRavenHandlerWhenADSNAndAClientAreSpecified()
@@ -329,7 +329,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', array('%monolog.use_microseconds%'));
         $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', array(new Reference('monolog.handler.loggly')));
         $handler = $container->getDefinition('monolog.handler.loggly');
-        $this->assertDICDefinitionClass($handler, '%monolog.handler.loggly.class%');
+        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\LogglyHandler');
         $this->assertDICConstructorArguments($handler, array($token, \Monolog\Logger::DEBUG, true));
         $this->assertEmpty($handler->getMethodCalls());
 


### PR DESCRIPTION
The idea was initially discussed in symfony/symfony/issues/11881.

If I understand things correctly, we should provide a service for each removed parameter to allow bundle users to decorate or override corresponding services.
But I'm not sure if services should be listed in DI config of bundle, or it is OK to add them during DI Extension load.

I'm using those services to map handler type to handler class (this is done [here](https://github.com/avant1/monolog-bundle/blob/remove-class-parameters/DependencyInjection/MonologExtension.php#L133-L134)). But those handler services can be replaced by hash mapping.

If anything else related to this changes should be done (like updating README or adding note to symfony logging cookbook) - I'm ready to work on this too.