### PR TITLE
Added content-type to schema

### DIFF
--- a/Resources/config/schema/monolog-1.0.xsd
+++ b/Resources/config/schema/monolog-1.0.xsd
@@ -82,6 +82,7 @@
         <xsd:attribute name="ignore-error" type="xsd:string" />
         <xsd:attribute name="api_version" type="xsd:string" />
         <xsd:attribute name="include-stacktraces" type="xsd:string" />
+        <xsd:attribute name="content-type" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:simpleType name="level">


### PR DESCRIPTION
content-type is missing from the XSD. making it impossible to use the swift_mailer handler to send HTML formatted emails with XML config