### PR TITLE
ability to configure whether messages should be formatted as PSR-3

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -311,6 +311,7 @@ class Configuration implements ConfigurationInterface
                             ->booleanNode('bubble')->defaultTrue()->end()
                             ->scalarNode('app_name')->defaultNull()->end()
                             ->booleanNode('include_stacktraces')->defaultFalse()->end()
+                            ->booleanNode('process_psr_3_messages')->defaultTrue()->end()
                             ->scalarNode('path')->defaultValue('%kernel.logs_dir%/%kernel.environment%.log')->end() // stream and rotating
                             ->scalarNode('file_permission')  // stream and rotating
                                 ->defaultNull()

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -138,6 +138,17 @@ class MonologExtension extends Extension
             $definition->setConfigurator(array('Symfony\\Bundle\\MonologBundle\\MonologBundle', 'includeStacktraces'));
         }
 
+        if ($handler['process_psr_3_messages']) {
+            $processorId = 'monolog.processor.psr_log_message';
+            if (!$container->hasDefinition($processorId)) {
+                $processor = new Definition('Monolog\\Processor\\PsrLogMessageProcessor');
+                $processor->setPublic(false);
+                $container->setDefinition($processorId, $processor);
+            }
+
+            $definition->addMethodCall('pushProcessor', array(new Reference($processorId)));
+        }
+
         switch ($handler['type']) {
         case 'service':
             $container->setAlias($handlerId, $handler['id']);

--- a/Resources/config/schema/monolog-1.0.xsd
+++ b/Resources/config/schema/monolog-1.0.xsd
@@ -32,6 +32,7 @@
         <xsd:attribute name="priority" type="xsd:integer" />
         <xsd:attribute name="level" type="level" />
         <xsd:attribute name="bubble" type="xsd:boolean" />
+        <xsd:attribute name="process-psr-3-messages" type="xsd:boolean" />
         <xsd:attribute name="app-name" type="xsd:string" />
         <xsd:attribute name="path" type="xsd:string" />
         <xsd:attribute name="id" type="xsd:string" />

--- a/Tests/DependencyInjection/FixtureMonologExtensionTest.php
+++ b/Tests/DependencyInjection/FixtureMonologExtensionTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\MonologBundle\Tests\DependencyInjection;
 use Symfony\Bundle\MonologBundle\DependencyInjection\MonologExtension;
 use Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\LoggerChannelPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
 abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
@@ -176,6 +177,22 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
             ),
             $container->getParameter('monolog.handlers_to_channels')
         );
+    }
+
+    public function testPsr3MessageProcessingDisabled()
+    {
+        $container = $this->getContainer('process_psr_3_messages_disabled');
+
+        $logger = $container->getDefinition('monolog.handler.custom');
+
+        $methodCalls = $logger->getMethodCalls();
+
+        foreach ($methodCalls as $methodCall) {
+            list($methodName, $params) = $methodCall;
+            if ($methodName === 'pushProcessor') {
+                $this->assertNotEquals(array(new Definition('monolog.processor.psr_log_message')), $params);
+            }
+        }
     }
 
     protected function getContainer($fixture)

--- a/Tests/DependencyInjection/Fixtures/xml/process_psr_3_messages_disabled.xml
+++ b/Tests/DependencyInjection/Fixtures/xml/process_psr_3_messages_disabled.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:monolog="http://symfony.com/schema/dic/monolog"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/monolog http://symfony.com/schema/dic/monolog/monolog-1.0.xsd">
+    <monolog:config>
+        <monolog:handler name="custom" type="stream" path="/tmp/symfony.log" process-psr-3-messages="false"/>
+    </monolog:config>
+</container>

--- a/Tests/DependencyInjection/Fixtures/yml/process_psr_3_messages_disabled.yml
+++ b/Tests/DependencyInjection/Fixtures/yml/process_psr_3_messages_disabled.yml
@@ -1,0 +1,6 @@
+monolog:
+    handlers:
+        custom:
+            type: stream
+            path: /tmp/symfony.log
+            process_psr_3_messages: false

--- a/Tests/DependencyInjection/MonologExtensionTest.php
+++ b/Tests/DependencyInjection/MonologExtensionTest.php
@@ -33,6 +33,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         $handler = $container->getDefinition('monolog.handler.main');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
         $this->assertDICConstructorArguments($handler, array('%kernel.logs_dir%/%kernel.environment%.log', \Monolog\Logger::DEBUG, true, null));
+        $this->assertDICDefinitionMethodCallAt(0, $handler, 'pushProcessor', array(new Reference('monolog.processor.psr_log_message')));
     }
 
     public function testLoadWithCustomValues()
@@ -232,10 +233,10 @@ class MonologExtensionTest extends DependencyInjectionTest
         $handler = $container->getDefinition('monolog.handler.socket');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\SocketHandler');
         $this->assertDICConstructorArguments($handler, array('localhost:50505', \Monolog\Logger::DEBUG, true));
-        $this->assertDICDefinitionMethodCallAt(0, $handler, 'setTimeout', array('1'));
-        $this->assertDICDefinitionMethodCallAt(1, $handler, 'setConnectionTimeout', array('0.6'));
-        $this->assertDICDefinitionMethodCallAt(2, $handler, 'setPersistent', array(true));
-
+        $this->assertDICDefinitionMethodCallAt(0, $handler, 'pushProcessor', array(new Reference('monolog.processor.psr_log_message')));
+        $this->assertDICDefinitionMethodCallAt(1, $handler, 'setTimeout', array('1'));
+        $this->assertDICDefinitionMethodCallAt(2, $handler, 'setConnectionTimeout', array('0.6'));
+        $this->assertDICDefinitionMethodCallAt(3, $handler, 'setPersistent', array(true));
     }
 
     public function testRavenHandlerWhenConfigurationIsWrong()
@@ -331,13 +332,14 @@ class MonologExtensionTest extends DependencyInjectionTest
         $handler = $container->getDefinition('monolog.handler.loggly');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\LogglyHandler');
         $this->assertDICConstructorArguments($handler, array($token, \Monolog\Logger::DEBUG, true));
-        $this->assertEmpty($handler->getMethodCalls());
+        $this->assertDICDefinitionMethodCallAt(0, $handler, 'pushProcessor', array(new Reference('monolog.processor.psr_log_message')));
 
         $container = $this->getContainer(array(array('handlers' => array('loggly' => array(
             'type' => 'loggly', 'token' => $token, 'tags' => array(' ', 'foo', '', 'bar'))
         ))));
         $handler = $container->getDefinition('monolog.handler.loggly');
-        $this->assertDICDefinitionMethodCallAt(0, $handler, 'setTag', array('foo,bar'));
+        $this->assertDICDefinitionMethodCallAt(0, $handler, 'pushProcessor', array(new Reference('monolog.processor.psr_log_message')));
+        $this->assertDICDefinitionMethodCallAt(1, $handler, 'setTag', array('foo,bar'));
     }
 
     public function testFingersCrossedHandlerWhenExcluded404sAreSpecified()


### PR DESCRIPTION
This PR https://github.com/symfony/symfony/pull/17166 (reasons described in https://github.com/symfony/symfony/issues/15753) has changed the way messages are logged in Symfony. Now log messages contain placeholders (see https://github.com/symfony/symfony-standard/issues/981).
While this could be a useful feature, IMO by default in SE messages should be preformatted.
This PR introduces a new optional config option that makes the messages be preformatted by default but this behaviour can also be disabled.
