### PR TITLE
Use "more entropy" option when using uniqid() function

### DIFF
--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -182,13 +182,13 @@ class MonologExtension extends Extension
                     $handler['publisher']['port'],
                     $handler['publisher']['chunk_size'],
                 ));
-                $transportId = uniqid('monolog.gelf.transport.');
+                $transportId = uniqid('monolog.gelf.transport.', true);
                 $transport->setPublic(false);
                 $container->setDefinition($transportId, $transport);
 
                 $publisher = new Definition('%monolog.gelfphp.publisher.class%', array());
                 $publisher->addMethodCall('addTransport', array(new Reference($transportId)));
-                $publisherId = uniqid('monolog.gelf.publisher.');
+                $publisherId = uniqid('monolog.gelf.publisher.', true);
                 $publisher->setPublic(false);
                 $container->setDefinition($publisherId, $publisher);
             } elseif (class_exists('Gelf\MessagePublisher')) {
@@ -198,7 +198,7 @@ class MonologExtension extends Extension
                     $handler['publisher']['chunk_size'],
                 ));
 
-                $publisherId = uniqid('monolog.gelf.publisher.');
+                $publisherId = uniqid('monolog.gelf.publisher.', true);
                 $publisher->setPublic(false);
                 $container->setDefinition($publisherId, $publisher);
             } else {
@@ -228,7 +228,7 @@ class MonologExtension extends Extension
                     $server,
                 ));
 
-                $clientId = uniqid('monolog.mongo.client.');
+                $clientId = uniqid('monolog.mongo.client.', true);
                 $client->setPublic(false);
                 $container->setDefinition($clientId, $client);
             }
@@ -269,7 +269,7 @@ class MonologExtension extends Extension
                     $elasticaClientArguments
                 ));
 
-                $clientId = uniqid('monolog.elastica.client.');
+                $clientId = uniqid('monolog.elastica.client.', true);
                 $elasticaClient->setPublic(false);
                 $container->setDefinition($clientId, $elasticaClient);
             }


### PR DESCRIPTION
As you can see in [the source code of the PHP uniqid() function](https://github.com/php/php-src/blob/1c295d4a9ac78fcc2f77d6695987598bb7abcb83/ext/standard/uniqid.c#L68) when you don't pass `true` as the second argument, PHP sleeps the application for 1 microsecond (`usleep(1)`)

Symfony uses `true` almost everywhere, but this bundle still had some uniqid() calls without this option.