### PR TITLE
Fix logger that logs to STDERR when no handlers are registered

### DIFF
--- a/DependencyInjection/Compiler/FixEmptyLoggerPass.php
+++ b/DependencyInjection/Compiler/FixEmptyLoggerPass.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MonologBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Fixes loggers with no handlers (by registering a "null" one).
+ *
+ * Monolog 1.x adds a default handler logging on STDERR when a logger has
+ * no registered handlers. This is NOT what what we want in Symfony, so in such
+ * cases, we add a "null" handler to avoid the issue.
+ *
+ * Note that Monolog 2.x does not register a default handler anymore, so this pass can
+ * be removed when MonologBundle minimum version of Monolog is bumped to 2.0.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @see https://github.com/Seldaek/monolog/commit/ad37b7b2d11f300cbace9f5e84f855d329519e28
+ */
+class FixEmptyLoggerPass implements CompilerPassInterface
+{
+    private $channelPass;
+
+    public function __construct(LoggerChannelPass $channelPass)
+    {
+        $this->channelPass = $channelPass;
+    }
+
+    public function process(ContainerBuilder $container)
+    {
+        $container->register('monolog.handler.null_internal', 'Monolog\Handler\NullHandler');
+        foreach ($this->channelPass->getChannels() as $channel) {
+            $def = $container->getDefinition($channel === 'app' ? 'monolog.logger' : 'monolog.logger.'.$channel);
+            foreach ($def->getMethodCalls() as $method) {
+                if ('pushHandler' === $method[0]) {
+                    continue 2;
+                }
+            }
+
+            $def->addMethodCall('pushHandler', array(new Reference('monolog.handler.null_internal')));
+        }
+    }
+}

--- a/MonologBundle.php
+++ b/MonologBundle.php
@@ -20,6 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\LoggerChannelPass;
 use Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\DebugHandlerPass;
 use Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\AddProcessorsPass;
+use Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\RemoveEmptyLoggerPass;
 
 /**
  * Bundle.
@@ -34,6 +35,7 @@ class MonologBundle extends Bundle
 
         $container->addCompilerPass($channelPass = new LoggerChannelPass());
         $container->addCompilerPass(new DebugHandlerPass($channelPass));
+        $container->addCompilerPass(new RemoveEmptyLoggerPass($channelPass));
         $container->addCompilerPass(new AddProcessorsPass());
         $container->addCompilerPass(new AddSwiftMailerTransportPass());
     }

--- a/Tests/DependencyInjection/Compiler/FixEmptyLoggerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/FixEmptyLoggerPassTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Compiler;
+
+use Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\FixEmptyLoggerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class FixEmptyLoggerPassTest extends \PHPUnit_Framework_TestCase
+{
+    public function testProcess()
+    {
+        $loggerChannelPass = $this->getMockBuilder('Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\LoggerChannelPass')->getMock();
+        $loggerChannelPass->expects($this->any())->method('getChannels')->will($this->returnValue(array('foo', 'bar')));
+
+        $container = new ContainerBuilder();
+        $container->register('monolog.logger.foo', 'Monolog\Logger');
+        $container->register('monolog.logger.bar', 'Monolog\Logger')->addMethodCall('pushHandler');
+
+        $pass = new FixEmptyLoggerPass($loggerChannelPass);
+        $pass->process($container);
+
+        $calls = $container->getDefinition('monolog.logger.foo')->getMethodCalls();
+        $this->assertCount(1, $calls);
+        $this->assertSame('pushHandler', $calls[0][0]);
+        $this->assertSame('monolog.handler.null_internal', (string) $calls[0][1][0]);
+
+        $calls = $container->getDefinition('monolog.logger.bar')->getMethodCalls();
+        $this->assertCount(1, $calls);
+    }
+}


### PR DESCRIPTION
Since Seldaek/monolog@ad37b7b, the `event` logger has no registered handlers in Symfony SE on the CLI. As Monolog 1.x automatically adds a STDERR handler when no handlers are registered, it means that logs (the event ones for instance) are output on STDERR by default with the Symfony CLI, which is exactly what we try to avoid.

So, this PR adds a new compiler pass to register a null handler when a logger has no registered handlers to avoid having the default STDERR handler from Monolog.
