### PR TITLE
Deprecate DebugHandlerPass in favor of AddDebugLogProcessorPass in FrameworkBundle

### DIFF
--- a/DependencyInjection/Compiler/DebugHandlerPass.php
+++ b/DependencyInjection/Compiler/DebugHandlerPass.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bundle\MonologBundle\DependencyInjection\Compiler;
 
+@trigger_error('The '.__NAMESPACE__.'\DebugHandlerPass class is deprecated since version 2.12 and will be removed in 3.0. Use AddDebugLogProcessorPass in FrameworkBundle instead.', E_USER_DEPRECATED);
+
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -22,6 +24,8 @@ use Monolog\Logger;
  *
  * @author Christophe Coevoet <stof@notk.org>
  * @author Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * @deprecated since version 2.12, to be removed in 3.0. Use AddDebugLogProcessorPass in FrameworkBundle instead.
  */
 class DebugHandlerPass implements CompilerPassInterface
 {

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -103,7 +103,6 @@ class MonologExtension extends Extension
                 'Monolog\\Handler\\TestHandler',
                 'Monolog\\Logger',
                 'Symfony\\Bridge\\Monolog\\Logger',
-                'Symfony\\Bridge\\Monolog\\Handler\\DebugHandler',
                 'Monolog\\Handler\\FingersCrossed\\ActivationStrategyInterface',
                 'Monolog\\Handler\\FingersCrossed\\ErrorLevelActivationStrategy',
             ));

--- a/MonologBundle.php
+++ b/MonologBundle.php
@@ -34,7 +34,9 @@ class MonologBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass($channelPass = new LoggerChannelPass());
-        $container->addCompilerPass(new DebugHandlerPass($channelPass));
+        if (!class_exists('Symfony\Bridge\Monolog\Processor\DebugProcessor')) {
+            $container->addCompilerPass(new DebugHandlerPass($channelPass));
+        }
         $container->addCompilerPass(new FixEmptyLoggerPass($channelPass));
         $container->addCompilerPass(new AddProcessorsPass());
         $container->addCompilerPass(new AddSwiftMailerTransportPass());

--- a/Tests/DependencyInjection/Fixtures/yml/parameterized_handlers.yml
+++ b/Tests/DependencyInjection/Fixtures/yml/parameterized_handlers.yml
@@ -4,11 +4,11 @@ parameters:
 services:
     foo_logger:
         class: Foo
-        tags: [{ name: monolog.logger, channel: %channel_parameter% }]
+        tags: [{ name: monolog.logger, channel: '%channel_parameter%' }]
 
 monolog:
     handlers:
         custom:
             type: stream
             path: /tmp/symfony.log
-            channels: %channel_parameter%
+            channels: '%channel_parameter%'


### PR DESCRIPTION
Related to https://github.com/symfony/symfony/pull/20416