### PR TITLE
bumped version of PHP to the minimal one of Symfony 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ cache:
         - $HOME/.composer/cache/files
 
 php:
-  - 5.3
-  - 5.4
   - 5.5
   - 7.0
   - hhvm
@@ -16,7 +14,7 @@ php:
 matrix:
   fast_finish: true
   include:
-    - php: 5.3
+    - php: 5.5
       env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER=weak
     # Test against Symfony LTS versions
     - php: 5.6

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.2",
+        "php": ">=5.5.9",
         "symfony/monolog-bridge": "~2.7|~3.0",
         "symfony/dependency-injection": "~2.7|~3.0",
         "symfony/config": "~2.7|~3.0",


### PR DESCRIPTION
As suggested by @Tobion, I propose to update the minimal PHP version as 2.7 does not support old PHP 5.3 versions anyway.