### PR TITLE
revert disabling DebugHandler in CLI environments

### DIFF
--- a/DependencyInjection/Compiler/DebugHandlerPass.php
+++ b/DependencyInjection/Compiler/DebugHandlerPass.php
@@ -46,11 +46,6 @@ class DebugHandlerPass implements CompilerPassInterface
             return;
         }
 
-        // disable the DebugHandler in CLI as it tends to leak memory if people enable kernel.debug
-        if ('cli' === PHP_SAPI) {
-            return;
-        }
-
         $debugHandler = new Definition('%monolog.handler.debug.class%', array(Logger::DEBUG, true));
         $container->setDefinition('monolog.handler.debug', $debugHandler);
 


### PR DESCRIPTION
As the cache is shared between the different server APIs, the debug handler needs to take care of abstaining itself.

After symfony/symfony#21061 being merged, the changes made in fbbcefd7821edfaa31a48712bba0960979243c1c should no longer be necessary.