### PR TITLE
Revert "Drop DebugHandlerPass"

### DIFF
--- a/DependencyInjection/Compiler/DebugHandlerPass.php
+++ b/DependencyInjection/Compiler/DebugHandlerPass.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MonologBundle\DependencyInjection\Compiler;
+
+@trigger_error('The '.__NAMESPACE__.'\DebugHandlerPass class is deprecated since version 2.12 and will be removed in 3.0. Use AddDebugLogProcessorPass in FrameworkBundle instead.', E_USER_DEPRECATED);
+
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Definition;
+use Monolog\Logger;
+
+/**
+ * Adds the DebugHandler when the profiler is enabled and kernel.debug is true.
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * @deprecated since version 2.12, to be removed in 3.0. Use AddDebugLogProcessorPass in FrameworkBundle instead.
+ */
+class DebugHandlerPass implements CompilerPassInterface
+{
+    private $channelPass;
+
+    public function __construct(LoggerChannelPass $channelPass)
+    {
+        $this->channelPass = $channelPass;
+    }
+
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('profiler')) {
+            return;
+        }
+
+        if (!$container->getParameter('kernel.debug')) {
+            return;
+        }
+
+        // disable the DebugHandler in CLI as it tends to leak memory if people enable kernel.debug
+        if ('cli' === PHP_SAPI) {
+            return;
+        }
+
+        $debugHandler = new Definition('Symfony\Bridge\Monolog\Handler\DebugHandler', array(Logger::DEBUG, true));
+        $container->setDefinition('monolog.handler.debug', $debugHandler);
+
+        foreach ($this->channelPass->getChannels() as $channel) {
+            $container
+                ->getDefinition($channel === 'app' ? 'monolog.logger' : 'monolog.logger.'.$channel)
+                ->addMethodCall('pushHandler', array(new Reference('monolog.handler.debug')));
+        }
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -249,6 +249,10 @@ use Monolog\Logger;
  *   - [level]: level name or int value, defaults to DEBUG
  *   - [bubble]: bool, defaults to true
  *
+ * - debug:
+ *   - [level]: level name or int value, defaults to DEBUG
+ *   - [bubble]: bool, defaults to true
+ *
  * - loggly:
  *   - token: loggly api token
  *   - [level]: level name or int value, defaults to DEBUG
@@ -763,6 +767,10 @@ class Configuration implements ConfigurationInterface
                             ->ifTrue(function ($v) { return 'flowdock' === $v['type'] && empty($v['source']); })
                             ->thenInvalid('The source has to be specified to use a FlowdockHandler')
                         ->end()
+                    ->end()
+                    ->validate()
+                        ->ifTrue(function ($v) { return isset($v['debug']); })
+                        ->thenInvalid('The "debug" name cannot be used as it is reserved for the handler of the profiler')
                     ->end()
                     ->example(array(
                         'syslog' => array(

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -681,6 +681,7 @@ class MonologExtension extends Extension
         case 'browser_console':
         case 'test':
         case 'null':
+        case 'debug':
             $definition->setArguments(array(
                 $handler['level'],
                 $handler['bubble'],
@@ -736,6 +737,7 @@ class MonologExtension extends Extension
             'browser_console' => 'Monolog\Handler\BrowserConsoleHandler',
             'firephp' => 'Symfony\Bridge\Monolog\Handler\FirePHPHandler',
             'chromephp' => 'Symfony\Bridge\Monolog\Handler\ChromePhpHandler',
+            'debug' => 'Symfony\Bridge\Monolog\Handler\DebugHandler',
             'swift_mailer' => 'Symfony\Bridge\Monolog\Handler\SwiftMailerHandler',
             'native_mailer' => 'Monolog\Handler\NativeMailerHandler',
             'socket' => 'Monolog\Handler\SocketHandler',

--- a/MonologBundle.php
+++ b/MonologBundle.php
@@ -18,6 +18,7 @@ use Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\AddSwiftMailerTran
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\LoggerChannelPass;
+use Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\DebugHandlerPass;
 use Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\AddProcessorsPass;
 use Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\FixEmptyLoggerPass;
 
@@ -33,6 +34,9 @@ class MonologBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass($channelPass = new LoggerChannelPass());
+        if (!class_exists('Symfony\Bridge\Monolog\Processor\DebugProcessor')) {
+            $container->addCompilerPass(new DebugHandlerPass($channelPass));
+        }
         $container->addCompilerPass(new FixEmptyLoggerPass($channelPass));
         $container->addCompilerPass(new AddProcessorsPass());
         $container->addCompilerPass(new AddSwiftMailerTransportPass());

--- a/Tests/DependencyInjection/MonologExtensionTest.php
+++ b/Tests/DependencyInjection/MonologExtensionTest.php
@@ -166,6 +166,18 @@ class MonologExtensionTest extends DependencyInjectionTest
         $loader->load(array(array('handlers' => array('main' => array('type' => 'service')))), $container);
     }
 
+    /**
+     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     */
+    public function testExceptionWhenUsingDebugName()
+    {
+        // logger
+        $container = new ContainerBuilder();
+        $loader = new MonologExtension();
+
+        $loader->load(array(array('handlers' => array('debug' => array('type' => 'stream')))), $container);
+    }
+
     public function testSyslogHandlerWithLogopts()
     {
         $container = $this->getContainer(array(array('handlers' => array('main' => array('type' => 'syslog', 'logopts' => LOG_CONS)))));


### PR DESCRIPTION
This reverts commit b46da89f264efa7ed42ed3db6b9b69a2b2ef2163.
The class is necessary to support Symfony <3.2. Closes #190.

The 3.x version of the bundle contains only 2 changes compared to 2.11:

- breaking support for Symfony <3.2 (while still announcing compatibility), which is what got reverted here
- adding support for a new Monolog feature (which could totally fit in 2.x btw).

As we still need to keep support for the Symfony LTS, and the 3.x series is currently broken for us, I'm suggesting here to revert the removal (effectively making it a follow-up of 2.x, which would allow to avoid maintaining 2 branches).
The other alternative would be to kill the existing 3.x releases entirely to forbid them to be installed in a Symfony 2.8 project allowing ``symfony/monolog-bundle: ^2.8 || ^3``, but composer does not support yanking existing tags, and git is bad at deleting them (deleting them would require deleting them in all existing clones to be sure that they would never be pushed again to the repo, and then deleting the Packagist versions).