### PR TITLE
Remove faulty service definitions

### DIFF
--- a/Resources/config/monolog.xml
+++ b/Resources/config/monolog.xml
@@ -18,9 +18,6 @@
             <argument /><!-- Channel -->
         </service>
 
-        <service id="monolog.activation_strategy.not_found" class="Symfony\Bridge\Monolog\Handler\FingersCrossed\NotFoundActivationStrategy"/>
-        <service id="monolog.handler.fingers_crossed.error_level_activation_strategy" class="Monolog\Handler\FingersCrossed\ErrorLevelActivationStrategy"/>
-
         <!-- Formatters -->
         <service id="monolog.formatter.chrome_php" class="Monolog\Formatter\ChromePHPFormatter" public="false" />
         <service id="monolog.formatter.gelf_message" class="Monolog\Formatter\GelfMessageFormatter" public="false" />


### PR DESCRIPTION
These definitions have been broken for a while now with the only people
noticing being those running smoke tests on their DICs so I'd suggest
they can actually be removed instead of fixed.

Closes #192