### PR TITLE
bug  #208 Slackbot handler does not work

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -219,7 +219,7 @@ use Monolog\Logger;
  *   - [bubble]: bool, defaults to true
  *
  * - slackbot:
- *   - team: slack team slug
+ *   - slack_team: slack team slug
  *   - token: slackbot token
  *   - channel: channel name (with starting #)
  *   - [level]: level name or int value, defaults to DEBUG
@@ -721,8 +721,8 @@ class Configuration implements ConfigurationInterface
                             ->thenInvalid('The webhook_url have to be specified to use a SlackWebhookHandler')
                         ->end()
                         ->validate()
-                            ->ifTrue(function ($v) { return 'slackbot' === $v['type'] && (empty($v['stack_team']) || empty($v['token']) || empty($v['channel'])); })
-                            ->thenInvalid('The stack_team, token and channel have to be specified to use a SlackbotHandler')
+                            ->ifTrue(function ($v) { return 'slackbot' === $v['type'] && (empty($v['slack_team']) || empty($v['token']) || empty($v['channel'])); })
+                            ->thenInvalid('The slack_team, token and channel have to be specified to use a SlackbotHandler')
                         ->end()
                         ->validate()
                             ->ifTrue(function ($v) { return 'cube' === $v['type'] && empty($v['url']); })

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -219,7 +219,7 @@ use Monolog\Logger;
  *   - [bubble]: bool, defaults to true
  *
  * - slackbot:
- *   - slack_team: slack team slug
+ *   - team: slack team slug
  *   - token: slackbot token
  *   - channel: channel name (with starting #)
  *   - [level]: level name or int value, defaults to DEBUG
@@ -380,7 +380,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('include_extra')->defaultFalse()->end() // slack & slackwebhook
                             ->scalarNode('icon_emoji')->defaultNull()->end() // slack & slackwebhook
                             ->scalarNode('webhook_url')->end() // slackwebhook
-                            ->scalarNode('slack_team')->end() // slackbot
+                            ->scalarNode('team')->end() // slackbot
                             ->scalarNode('notify')->defaultFalse()->end() // hipchat
                             ->scalarNode('nickname')->defaultValue('Monolog')->end() // hipchat
                             ->scalarNode('token')->end() // pushover & hipchat & loggly & logentries & flowdock & rollbar & slack & slackbot
@@ -721,8 +721,8 @@ class Configuration implements ConfigurationInterface
                             ->thenInvalid('The webhook_url have to be specified to use a SlackWebhookHandler')
                         ->end()
                         ->validate()
-                            ->ifTrue(function ($v) { return 'slackbot' === $v['type'] && (empty($v['slack_team']) || empty($v['token']) || empty($v['channel'])); })
-                            ->thenInvalid('The slack_team, token and channel have to be specified to use a SlackbotHandler')
+                            ->ifTrue(function ($v) { return 'slackbot' === $v['type'] && (empty($v['team']) || empty($v['token']) || empty($v['channel'])); })
+                            ->thenInvalid('The team, token and channel have to be specified to use a SlackbotHandler')
                         ->end()
                         ->validate()
                             ->ifTrue(function ($v) { return 'cube' === $v['type'] && empty($v['url']); })

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -550,7 +550,7 @@ class MonologExtension extends Extension
 
         case 'slackbot':
             $definition->setArguments(array(
-                $handler['slack_team'],
+                $handler['team'],
                 $handler['token'],
                 urlencode($handler['channel']),
                 $handler['level'],

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -552,7 +552,7 @@ class MonologExtension extends Extension
             $definition->setArguments(array(
                 $handler['slack_team'],
                 $handler['token'],
-                $handler['channel'],
+                urlencode($handler['channel']),
                 $handler['level'],
                 $handler['bubble'],
             ));


### PR DESCRIPTION
Slackbot handler does not work, because there is grammar mistake and curl can not handle # sign from channel name.