### PR TITLE
Allow to override VERBOSITY_QUIET in configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -528,7 +528,7 @@ class Configuration implements ConfigurationInterface
                                     ->ifArray()
                                     ->then(function ($v) {
                                         $map = array();
-                                        $verbosities = array('VERBOSITY_NORMAL', 'VERBOSITY_VERBOSE', 'VERBOSITY_VERY_VERBOSE', 'VERBOSITY_DEBUG');
+                                        $verbosities = array('VERBOSITY_QUIET', 'VERBOSITY_NORMAL', 'VERBOSITY_VERBOSE', 'VERBOSITY_VERY_VERBOSE', 'VERBOSITY_DEBUG');
                                         // allow numeric indexed array with ascendning verbosity and lowercase names of the constants
                                         foreach ($v as $verbosity => $level) {
                                             if (is_int($verbosity) && isset($verbosities[$verbosity])) {
@@ -542,6 +542,7 @@ class Configuration implements ConfigurationInterface
                                     })
                                 ->end()
                                 ->children()
+                                    ->scalarNode('VERBOSITY_QUIET')->defaultValue('ERROR')->end()
                                     ->scalarNode('VERBOSITY_NORMAL')->defaultValue('WARNING')->end()
                                     ->scalarNode('VERBOSITY_VERBOSE')->defaultValue('NOTICE')->end()
                                     ->scalarNode('VERBOSITY_VERY_VERBOSE')->defaultValue('INFO')->end()

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -267,6 +267,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             OutputInterface::VERBOSITY_NORMAL => Logger::NOTICE,
             OutputInterface::VERBOSITY_VERBOSE => Logger::INFO,
             OutputInterface::VERBOSITY_VERY_VERBOSE => 150,
+            OutputInterface::VERBOSITY_QUIET => Logger::ERROR,
             OutputInterface::VERBOSITY_DEBUG => Logger::DEBUG
         ), $config['handlers']['console']['verbosity_levels']);
     }


### PR DESCRIPTION
VERBOSITY_QUIET is set to ERROR by default and you can't override that, even though the OutputInterface allows to use this verbosity. In the default configuration, quiet doesn't mean really quiet as errors are still logged.