### PR TITLE
Combine multiple isset() calls when possible

### DIFF
--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -263,7 +263,7 @@ class MonologExtension extends Extension
                     'transport' => $handler['elasticsearch']['transport'],
                 );
 
-                if (isset($handler['elasticsearch']['user']) && isset($handler['elasticsearch']['password'])) {
+                if (isset($handler['elasticsearch']['user'], $handler['elasticsearch']['password'])) {
                     $elasticaClientArguments = array_merge(
                         $elasticaClientArguments,
                         array(


### PR DESCRIPTION
`isset($a) && isset($b)` is the same as `isset($a, $b)`, so we can save 1 function call. We did the same for Symfony: https://github.com/symfony/symfony/pull/22684 and https://github.com/symfony/symfony/pull/22685