### PR TITLE
Add configuration for new HttpCodeActivationStrategy

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -89,7 +89,7 @@ use Monolog\Logger;
  *   - handler: the wrapped handler's name
  *   - [action_level|activation_strategy]: minimum level or service id to activate the handler, defaults to WARNING
  *   - [excluded_404s]: if set, the strategy will be changed to one that excludes 404s coming from URLs matching any of those patterns
- *   - [excluded_http_codes]: if set, the strategy will be changed to one that excludes specific HTTP codes
+ *   - [excluded_http_codes]: if set, the strategy will be changed to one that excludes specific HTTP codes (requires Symfony Monolog bridge 4.1+)
  *   - [buffer_size]: defaults to 0 (unlimited)
  *   - [stop_buffering]: bool to disable buffering once the handler has been activated, defaults to true
  *   - [passthru_level]: level name or int value for messages to always flush, disabled by default
@@ -383,19 +383,17 @@ class Configuration implements ConfigurationInterface
                                              */
 
                                             if (is_array($value)) {
-                                                return isset($value['code'])
-                                                    ? $value
-                                                    : array('code' => key($value), 'url' => current($value));
+                                                return isset($value['code']) ? $value : array('code' => key($value), 'urls' => current($value));
                                             }
 
-                                            return array('code' => $value, 'url' => array());
+                                            return array('code' => $value, 'urls' => array());
                                         }, $values);
                                     })
                                 ->end()
                                 ->prototype('array')
                                     ->children()
                                         ->scalarNode('code')->end()
-                                        ->arrayNode('url')
+                                        ->arrayNode('urls')
                                             ->prototype('scalar')->end()
                                         ->end()
                                     ->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -89,6 +89,7 @@ use Monolog\Logger;
  *   - handler: the wrapped handler's name
  *   - [action_level|activation_strategy]: minimum level or service id to activate the handler, defaults to WARNING
  *   - [excluded_404s]: if set, the strategy will be changed to one that excludes 404s coming from URLs matching any of those patterns
+ *   - [excluded_http_codes]: if set, the strategy will be changed to one that excludes specific HTTP codes
  *   - [buffer_size]: defaults to 0 (unlimited)
  *   - [stop_buffering]: bool to disable buffering once the handler has been activated, defaults to true
  *   - [passthru_level]: level name or int value for messages to always flush, disabled by default
@@ -316,6 +317,7 @@ class Configuration implements ConfigurationInterface
                     ->prototype('array')
                         ->fixXmlConfig('member')
                         ->fixXmlConfig('excluded_404')
+                        ->fixXmlConfig('excluded_http_code')
                         ->fixXmlConfig('tag')
                         ->fixXmlConfig('accepted_level')
                         ->canBeUnset()
@@ -362,6 +364,42 @@ class Configuration implements ConfigurationInterface
                             ->arrayNode('excluded_404s') // fingers_crossed
                                 ->canBeUnset()
                                 ->prototype('scalar')->end()
+                            ->end()
+                            ->arrayNode('excluded_http_codes') // fingers_crossed
+                                ->canBeUnset()
+                                ->beforeNormalization()
+                                    ->always(function ($values) {
+                                        return array_map(function ($value) {
+                                            /*
+                                             * Allows YAML:
+                                             *   excluded_http_codes: [403, 404, { 400: ['^/foo', '^/bar'] }]
+                                             *
+                                             * and XML:
+                                             *   <monolog:excluded-http-code code="403">
+                                             *     <monolog:url>^/foo</monolog:url>
+                                             *     <monolog:url>^/bar</monolog:url>
+                                             *   </monolog:excluded-http-code>
+                                             *   <monolog:excluded-http-code code="404" />
+                                             */
+
+                                            if (is_array($value)) {
+                                                return isset($value['code'])
+                                                    ? $value
+                                                    : array('code' => key($value), 'url' => current($value));
+                                            }
+
+                                            return array('code' => $value, 'url' => array());
+                                        }, $values);
+                                    })
+                                ->end()
+                                ->prototype('array')
+                                    ->children()
+                                        ->scalarNode('code')->end()
+                                        ->arrayNode('url')
+                                            ->prototype('scalar')->end()
+                                        ->end()
+                                    ->end()
+                                ->end()
                             ->end()
                             ->arrayNode('accepted_levels') // filter
                                 ->canBeUnset()
@@ -657,6 +695,14 @@ class Configuration implements ConfigurationInterface
                         ->validate()
                             ->ifTrue(function ($v) { return 'fingers_crossed' === $v['type'] && !empty($v['excluded_404s']) && !empty($v['activation_strategy']); })
                             ->thenInvalid('You can not use excluded_404s together with a custom activation_strategy in a FingersCrossedHandler')
+                        ->end()
+                        ->validate()
+                            ->ifTrue(function ($v) { return 'fingers_crossed' === $v['type'] && !empty($v['excluded_http_codes']) && !empty($v['activation_strategy']); })
+                            ->thenInvalid('You can not use excluded_http_codes together with a custom activation_strategy in a FingersCrossedHandler')
+                        ->end()
+                        ->validate()
+                            ->ifTrue(function ($v) { return 'fingers_crossed' === $v['type'] && !empty($v['excluded_http_codes']) && !empty($v['excluded_404s']); })
+                            ->thenInvalid('You can not use excluded_http_codes together with excluded_404s in a FingersCrossedHandler')
                         ->end()
                         ->validate()
                             ->ifTrue(function ($v) { return 'filter' === $v['type'] && "DEBUG" !== $v['min_level'] && !empty($v['accepted_levels']); })

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -325,6 +325,9 @@ class MonologExtension extends Extension
                 $container->setDefinition($handlerId.'.not_found_strategy', $activationDef);
                 $activation = new Reference($handlerId.'.not_found_strategy');
             } elseif (!empty($handler['excluded_http_codes'])) {
+                if (!class_exists('Symfony\Bridge\Monolog\Handler\FingersCrossed\HttpCodeActivationStrategy')) {
+                    throw new \LogicException('"excluded_http_codes" cannot be used as your version of Monolog bridge does not support it.');
+                }
                 $activationDef = new Definition('Symfony\Bridge\Monolog\Handler\FingersCrossed\HttpCodeActivationStrategy', array(
                     new Reference('request_stack'),
                     $handler['excluded_http_codes'],

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -324,6 +324,14 @@ class MonologExtension extends Extension
                 ));
                 $container->setDefinition($handlerId.'.not_found_strategy', $activationDef);
                 $activation = new Reference($handlerId.'.not_found_strategy');
+            } elseif (!empty($handler['excluded_http_codes'])) {
+                $activationDef = new Definition('Symfony\Bridge\Monolog\Handler\FingersCrossed\HttpCodeActivationStrategy', array(
+                    new Reference('request_stack'),
+                    $handler['excluded_http_codes'],
+                    $handler['action_level']
+                ));
+                $container->setDefinition($handlerId.'.http_code_strategy', $activationDef);
+                $activation = new Reference($handlerId.'.http_code_strategy');
             } else {
                 $activation = $handler['action_level'];
             }

--- a/Resources/config/schema/monolog-1.0.xsd
+++ b/Resources/config/schema/monolog-1.0.xsd
@@ -24,6 +24,7 @@
             <xsd:element name="elasticsearch" type="elasticsearch" minOccurs="0" maxOccurs="1" />
             <xsd:element name="config" type="xsd:anyType" minOccurs="0" maxOccurs="1" />
             <xsd:element name="excluded-404" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="excluded-http-code" type="excluded-http-code" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="tag" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="accepted-level" type="level" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="to-email" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
@@ -162,5 +163,12 @@
         <xsd:attribute name="transport" type="xsd:string" />
         <xsd:attribute name="user" type="xsd:string" />
         <xsd:attribute name="password" type="xsd:string" />
+    </xsd:complexType>
+
+    <xsd:complexType name="excluded-http-code">
+        <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:element name="url" type="xsd:string" />
+        </xsd:choice>
+        <xsd:attribute name="code" type="xsd:integer" />
     </xsd:complexType>
 </xsd:schema>

--- a/Tests/DependencyInjection/MonologExtensionTest.php
+++ b/Tests/DependencyInjection/MonologExtensionTest.php
@@ -385,6 +385,10 @@ class MonologExtensionTest extends DependencyInjectionTest
 
     public function testFingersCrossedHandlerWhenExcludedHttpCodesAreSpecified()
     {
+        if (!class_exists('Symfony\Bridge\Monolog\Handler\FingersCrossed\HttpCodeActivationStrategy')) {
+            $this->markTestSkipped('Symfony Monolog 4.1+ is needed.');
+        }
+
         $container = $this->getContainer(array(array('handlers' => array(
             'main' => array(
                 'type' => 'fingers_crossed',
@@ -408,9 +412,9 @@ class MonologExtensionTest extends DependencyInjectionTest
         $this->assertDICConstructorArguments($strategy, array(
             new Reference('request_stack'),
             array(
-                array('code' => 403, 'url' => array()),
-                array('code' => 404, 'url' => array()),
-                array('code' => 405, 'url' => array('^/foo', '^/bar'))
+                array('code' => 403, 'urls' => array()),
+                array('code' => 404, 'urls' => array()),
+                array('code' => 405, 'urls' => array('^/foo', '^/bar'))
             ),
             \Monolog\Logger::WARNING
         ));

--- a/Tests/DependencyInjection/MonologExtensionTest.php
+++ b/Tests/DependencyInjection/MonologExtensionTest.php
@@ -383,6 +383,43 @@ class MonologExtensionTest extends DependencyInjectionTest
         $this->assertDICConstructorArguments($handler, array(new Reference('monolog.handler.nested'), new Reference('monolog.handler.main.not_found_strategy'), 0, true, true, null));
     }
 
+    public function testFingersCrossedHandlerWhenExcludedHttpCodesAreSpecified()
+    {
+        $container = $this->getContainer(array(array('handlers' => array(
+            'main' => array(
+                'type' => 'fingers_crossed',
+                'handler' => 'nested',
+                'excluded_http_codes' => array(403, 404, array(405 => array('^/foo', '^/bar')))
+            ),
+            'nested' => array('type' => 'stream', 'path' => '/tmp/symfony.log')
+        ))));
+
+        $this->assertTrue($container->hasDefinition('monolog.logger'));
+        $this->assertTrue($container->hasDefinition('monolog.handler.main'));
+        $this->assertTrue($container->hasDefinition('monolog.handler.nested'));
+        $this->assertTrue($container->hasDefinition('monolog.handler.main.http_code_strategy'));
+
+        $logger = $container->getDefinition('monolog.logger');
+        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', array('%monolog.use_microseconds%'));
+        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', array(new Reference('monolog.handler.main')));
+
+        $strategy = $container->getDefinition('monolog.handler.main.http_code_strategy');
+        $this->assertDICDefinitionClass($strategy, 'Symfony\Bridge\Monolog\Handler\FingersCrossed\HttpCodeActivationStrategy');
+        $this->assertDICConstructorArguments($strategy, array(
+            new Reference('request_stack'),
+            array(
+                array('code' => 403, 'url' => array()),
+                array('code' => 404, 'url' => array()),
+                array('code' => 405, 'url' => array('^/foo', '^/bar'))
+            ),
+            \Monolog\Logger::WARNING
+        ));
+
+        $handler = $container->getDefinition('monolog.handler.main');
+        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\FingersCrossedHandler');
+        $this->assertDICConstructorArguments($handler, array(new Reference('monolog.handler.nested'), new Reference('monolog.handler.main.http_code_strategy'), 0, true, true, null));
+    }
+
     protected function getContainer(array $config = array(), array $thirdPartyDefinitions = array())
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
Dependent upon https://github.com/symfony/symfony/pull/23707

This PR introduces configuration to integrate a new `HttpCodeActivationStrategy`, offering an easy way to ignore specific HTTP status codes.