### PR TITLE
Add formatter_options to console handler

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -33,6 +33,7 @@ use Monolog\Logger;
  *   - [bubble]: bool, defaults to true
  *
  * - console:
+ *   - [formatter_options]: option name => option value
  *   - [verbosity_levels]: level => verbosity configuration
  *   - [level]: level name or int value, defaults to DEBUG
  *   - [bubble]: bool, defaults to true
@@ -584,6 +585,10 @@ class Configuration implements ConfigurationInterface
                                         return $map;
                                     })
                                 ->end()
+                            ->end()
+                            ->arrayNode('formatter_options') // console
+                                ->canBeUnset()
+                                ->prototype('scalar')->end()
                             ->end()
                             ->arrayNode('channels')
                                 ->fixXmlConfig('channel', 'elements')

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -170,6 +170,7 @@ class MonologExtension extends Extension
                 null,
                 $handler['bubble'],
                 isset($handler['verbosity_levels']) ? $handler['verbosity_levels'] : array(),
+                isset($handler['formatter_options']) ? $handler['formatter_options'] : array(),
             ));
             $definition->addTag('kernel.event_subscriber');
             break;

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -255,6 +255,12 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                             'verbosity_verbose' => 'info',
                             'VERBOSITY_very_VERBOSE' => 150
                         )
+                    ),
+                    'console_with_options' => array(
+                        'type' => 'console',
+                        'formatter_options' => array(
+                            'some_option' => 'whatever',
+                        ),
                     )
                 )
             )
@@ -270,6 +276,13 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             OutputInterface::VERBOSITY_QUIET => Logger::ERROR,
             OutputInterface::VERBOSITY_DEBUG => Logger::DEBUG
         ), $config['handlers']['console']['verbosity_levels']);
+        $this->assertSame(array(), $config['handlers']['console']['formatter_options']);
+
+        $this->assertSame('console', $config['handlers']['console_with_options']['type']);
+        $this->assertSame(
+            array('some_option' => 'whatever'),
+            $config['handlers']['console_with_options']['formatter_options']
+        );
     }
 
     public function testWithType()


### PR DESCRIPTION
This patch is only applicable if this PR https://github.com/symfony/symfony/pull/23929 gets merged.

I'm not exactly sure about the changes in `Configuration.php`, so please take a closer look and let me eventually know if I should change something. Thanks, cheers!