### PR TITLE
Add PHP 7.1 & 7.2 to Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ php:
   - 5.5
   - 7.0
   - 7.1
+  - 7.2
   - hhvm
 
 matrix:
@@ -25,6 +26,8 @@ matrix:
     - php: 5.6
       env: SYMFONY_VERSION="2.8.*" DEPENDENCIES=dev
     - php: 7.1
+      env: SYMFONY_VERSION="2.8.*" DEPENDENCIES=dev
+    - php: 7.2
       env: SYMFONY_VERSION="2.8.*" DEPENDENCIES=dev
     # Test against dev versions
     - php: 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ php:
   - 5.4
   - 5.5
   - 7.0
+  - 7.1
   - hhvm
 
 matrix:
@@ -23,8 +24,12 @@ matrix:
       env: SYMFONY_VERSION="2.7.*"
     - php: 5.6
       env: SYMFONY_VERSION="2.8.*" DEPENDENCIES=dev
+    - php: 7.1
+      env: SYMFONY_VERSION="2.8.*" DEPENDENCIES=dev
     # Test against dev versions
     - php: 5.6
+      env: DEPENDENCIES=dev
+    - php: 7.1
       env: DEPENDENCIES=dev
   allow_failures:
     - env: DEPENDENCIES=dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,8 @@ matrix:
       env: SYMFONY_VERSION="2.7.*"
     - php: 5.6
       env: SYMFONY_VERSION="2.8.*" DEPENDENCIES=dev
-    - php: 7.1
-      env: SYMFONY_VERSION="2.8.*" DEPENDENCIES=dev
-    - php: 7.2
-      env: SYMFONY_VERSION="2.8.*" DEPENDENCIES=dev
     # Test against dev versions
     - php: 5.6
-      env: DEPENDENCIES=dev
-    - php: 7.1
       env: DEPENDENCIES=dev
   allow_failures:
     - env: DEPENDENCIES=dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ matrix:
       env: DEPENDENCIES=dev
   allow_failures:
     - env: DEPENDENCIES=dev
+    - php: 7.2
 
 before_install:
     - composer self-update


### PR DESCRIPTION
This PR helps ensure that this package works against the current versions of PHP. As seen in issue #223 , this package cannot be used with PHP 7.2.

Since PHP 7.2 is currently RC, I have included the instruction to ignore failed tests for PHP 7.2. Once PHP 7.2 is released, commit 1a4ef65 can be reverted so that errors against PHP 7.2 are no longer ignored.
