### PR TITLE
Fix invalid use of count() in PHP 7.2

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -651,7 +651,7 @@ class Configuration implements ConfigurationInterface
                             ->thenInvalid('Service handlers can not have a formatter configured in the bundle, you must reconfigure the service itself instead')
                         ->end()
                         ->validate()
-                            ->ifTrue(function ($v) { return ('fingers_crossed' === $v['type'] || 'buffer' === $v['type'] || 'filter' === $v['type']) && 1 !== count($v['handler']); })
+                            ->ifTrue(function ($v) { return ('fingers_crossed' === $v['type'] || 'buffer' === $v['type'] || 'filter' === $v['type']) && empty($v['handler']); })
                             ->thenInvalid('The handler has to be specified to use a FingersCrossedHandler or BufferHandler or FilterHandler')
                         ->end()
                         ->validate()


### PR DESCRIPTION
ref https://github.com/symfony/monolog-bundle/issues/223

PHP 7.2+ issues a warning when trying to count a non Iterable. The case in this code is not clear if it should just check for the presence of a handler or not. I suspect the original intention was to make sure the specified handler is defined in the configuration, but this should happen in the Extension?