### PR TITLE
Prepared MonologBundle for Symfony 4

### DIFF
--- a/Resources/config/monolog.xml
+++ b/Resources/config/monolog.xml
@@ -12,16 +12,16 @@
             </call>
         </service>
 
-        <service id="logger" alias="monolog.logger" />
+        <service id="logger" alias="monolog.logger" public="true" />
 
         <service id="Psr\Log\LoggerInterface" alias="logger" public="false" />
 
-        <service id="monolog.logger_prototype" class="Symfony\Bridge\Monolog\Logger" abstract="true">
+        <service id="monolog.logger_prototype" class="Symfony\Bridge\Monolog\Logger" abstract="true" public="true">
             <argument /><!-- Channel -->
         </service>
 
-        <service id="monolog.activation_strategy.not_found" class="Symfony\Bridge\Monolog\Handler\FingersCrossed\NotFoundActivationStrategy"/>
-        <service id="monolog.handler.fingers_crossed.error_level_activation_strategy" class="Monolog\Handler\FingersCrossed\ErrorLevelActivationStrategy"/>
+        <service id="monolog.activation_strategy.not_found" class="Symfony\Bridge\Monolog\Handler\FingersCrossed\NotFoundActivationStrategy" public="true"/>
+        <service id="monolog.handler.fingers_crossed.error_level_activation_strategy" class="Monolog\Handler\FingersCrossed\ErrorLevelActivationStrategy" public="true"/>
 
         <!-- Formatters -->
         <service id="monolog.formatter.chrome_php" class="Monolog\Formatter\ChromePHPFormatter" public="false" />

--- a/Resources/config/monolog.xml
+++ b/Resources/config/monolog.xml
@@ -16,12 +16,12 @@
 
         <service id="Psr\Log\LoggerInterface" alias="logger" public="false" />
 
-        <service id="monolog.logger_prototype" class="Symfony\Bridge\Monolog\Logger" abstract="true" public="true">
+        <service id="monolog.logger_prototype" class="Symfony\Bridge\Monolog\Logger" abstract="true">
             <argument /><!-- Channel -->
         </service>
 
-        <service id="monolog.activation_strategy.not_found" class="Symfony\Bridge\Monolog\Handler\FingersCrossed\NotFoundActivationStrategy" public="true"/>
-        <service id="monolog.handler.fingers_crossed.error_level_activation_strategy" class="Monolog\Handler\FingersCrossed\ErrorLevelActivationStrategy" public="true"/>
+        <service id="monolog.activation_strategy.not_found" class="Symfony\Bridge\Monolog\Handler\FingersCrossed\NotFoundActivationStrategy"/>
+        <service id="monolog.handler.fingers_crossed.error_level_activation_strategy" class="Monolog\Handler\FingersCrossed\ErrorLevelActivationStrategy"/>
 
         <!-- Formatters -->
         <service id="monolog.formatter.chrome_php" class="Monolog\Formatter\ChromePHPFormatter" public="false" />


### PR DESCRIPTION
In Symfony 3 the `public` parameter for service definitions is defaulted to `true`, while in Symfony 4 it is defaulted to `false`.
In order to keep MonologBundle working with both major versions, all we need to do is to explicitly set that parameter on all service definitions.

This Pull Request adds `public="true"` to all service definitions that didn't specify it.