### PR TITLE
Remove obsolete warnings in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,6 @@ MonologBundle
 The `MonologBundle` provides integration of the [Monolog](https://github.com/Seldaek/monolog)
 library into the Symfony2 framework.
 
-As of v2.4.0 of the bundle, the release cycle is de-synchronized from the framework's.
-It means you can just require `"symfony/monolog-bundle": "~2.4"` in your composer.json
-and Composer will automatically pick the latest version of the bundle that works with
-your current version of Symfony. The minimum version of Symfony2 for this workflow
-is 2.3.0.
-
 More information in the official [documentation](http://symfony.com/doc/current/cookbook/logging/index.html).
 
 License


### PR DESCRIPTION
Not affecting any supported Symfony versions, and even downright wrong since major version 3 was released.