### PR TITLE
Add ignore_error option to gelf handler

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -46,7 +46,7 @@ use Monolog\Logger;
  *   - [bubble]: bool, defaults to true
  *
  * - gelf:
- *   - publisher: {id: ...} or {hostname: ..., port: ..., chunk_size: ...}
+ *   - publisher: {id: ...} or {hostname: ..., port: ..., chunk_size: ..., ignore_error: ...}
  *   - [level]: level name or int value, defaults to DEBUG
  *   - [bubble]: bool, defaults to true
  *
@@ -413,6 +413,7 @@ class Configuration implements ConfigurationInterface
                                     ->scalarNode('hostname')->end()
                                     ->scalarNode('port')->defaultValue(12201)->end()
                                     ->scalarNode('chunk_size')->defaultValue(1420)->end()
+                                    ->booleanNode('ignore_error')->defaultValue(false)->end()
                                 ->end()
                                 ->validate()
                                     ->ifTrue(function ($v) {


### PR DESCRIPTION
`ignore_error` option to gelf handler wraps the transport inside the provided [`Gelf\Transport\IgnoreErrorTransportWrapper`](https://github.com/bzikarsky/gelf-php/blob/152c155df9795d62a096fd134e43671c13cc0e37/src/Gelf/Transport/IgnoreErrorTransportWrapper.php) added in graylog2/gelf-php:1.5 release.

To respect default behavior, it is set to `false` by default.

Thus, one can configure the gelf handler using basic configuration without the need to create a dedicated service.

The same option seems to exist for [elasticsearch](https://github.com/symfony/monolog-bundle/blob/2b41b8b6d2c6edb1a5494f02f8e4129be2a44784/DependencyInjection/Configuration.php#L475) [handler](https://github.com/symfony/monolog-bundle/blob/2b41b8b6d2c6edb1a5494f02f8e4129be2a44784/DependencyInjection/MonologExtension.php#L292) but I'm not sure it does the same thing (:O