### PR TITLE
Switch to namespaced PHPUnit classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ matrix:
       env: DEPENDENCIES=dev
     - php: 7.0
     - php: 7.1
+    - php: 7.2
     - php: hhvm
   allow_failures:
     - env: DEPENDENCIES=dev

--- a/Tests/DependencyInjection/Compiler/AddProcessorsPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddProcessorsPassTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Compiler;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\AddProcessorsPass;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Definition;
@@ -18,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
-class AddProcessorsPassTest extends \PHPUnit_Framework_TestCase
+class AddProcessorsPassTest extends TestCase
 {
     public function testHandlerProcessors()
     {

--- a/Tests/DependencyInjection/Compiler/AddSwiftMailerTransportPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddSwiftMailerTransportPassTest.php
@@ -11,13 +11,14 @@
 
 namespace Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Compiler;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\AddSwiftMailerTransportPass;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @author Christian Flothmann <christian.flothmann@xabbuh.de>
  */
-class AddSwiftMailerTransportPassTest extends \PHPUnit_Framework_TestCase
+class AddSwiftMailerTransportPassTest extends TestCase
 {
     private $compilerPass;
 

--- a/Tests/DependencyInjection/Compiler/FixEmptyLoggerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/FixEmptyLoggerPassTest.php
@@ -11,10 +11,11 @@
 
 namespace Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Compiler;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\FixEmptyLoggerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class FixEmptyLoggerPassTest extends \PHPUnit_Framework_TestCase
+class FixEmptyLoggerPassTest extends TestCase
 {
     public function testProcess()
     {

--- a/Tests/DependencyInjection/Compiler/LoggerChannelPassTest.php
+++ b/Tests/DependencyInjection/Compiler/LoggerChannelPassTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Compiler;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -18,7 +19,7 @@ use Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\LoggerChannelPass;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
-class LoggerChannelPassTest extends \PHPUnit_Framework_TestCase
+class LoggerChannelPassTest extends TestCase
 {
     public function testProcess()
     {

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -12,11 +12,12 @@
 namespace Symfony\Bundle\MonologBundle\Tests\DependencyInjection;
 
 use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MonologBundle\DependencyInjection\Configuration;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class ConfigurationTest extends TestCase
 {
     /**
      * Some basic tests to make sure the configuration is correctly processed in

--- a/Tests/DependencyInjection/DependencyInjectionTest.php
+++ b/Tests/DependencyInjection/DependencyInjectionTest.php
@@ -11,7 +11,9 @@
 
 namespace Symfony\Bundle\MonologBundle\Tests\DependencyInjection;
 
-abstract class DependencyInjectionTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+abstract class DependencyInjectionTest extends TestCase
 {
     /**
      * Assertion on the Class of a DIC Service Definition.


### PR DESCRIPTION
This PR switches the PHPUnit test base class from PEAR-style `PHPUnit_Framework_TestCase` to the namespaced `PHPUnit\Framework\TestCase`, which enables us to run the tests with PHPUnit 6 as well.