### PR TITLE
Enforce that channels defined in the config are public loggers

### DIFF
--- a/DependencyInjection/Compiler/LoggerChannelPass.php
+++ b/DependencyInjection/Compiler/LoggerChannelPass.php
@@ -68,6 +68,7 @@ class LoggerChannelPass implements CompilerPassInterface
         foreach ($container->getParameter('monolog.additional_channels') as $chan) {
             $loggerId = sprintf('monolog.logger.%s', $chan);
             $this->createLogger($chan, $loggerId, $container);
+            $container->getDefinition($loggerId)->setPublic(true);
         }
         $container->getParameterBag()->remove('monolog.additional_channels');
 


### PR DESCRIPTION
Channels can be created for 2 reasons:
- because a service requests to use it through the monolog.logger tag, in which case a private channel is fine (as it is injected using the DIC)
- because the bundle config asks to create it. In this case, the channel should be a public service, as the use case is to be able to use this channel through public access (otherwise, the previous way would have been used).

This is an improved versions over #247 as only channels created through config become public in Symfony 4.

/cc @derrabus 