### PR TITLE
add ident as parameter for syslogudp handler

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -138,7 +138,7 @@ use Monolog\Logger;
  *   - [logopts]: defaults to LOG_PID
  *   - [level]: level name or int value, defaults to DEBUG
  *   - [bubble]: bool, defaults to true
- *   - [ident]: string, program name or tag for each log message, defaults to php
+ *   - [ident]: string, program name or tag for each log message, defaults to 'php'
  *
  * - swift_mailer:
  *   - from_email: optional if email_prototype is given

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -138,6 +138,7 @@ use Monolog\Logger;
  *   - [logopts]: defaults to LOG_PID
  *   - [level]: level name or int value, defaults to DEBUG
  *   - [bubble]: bool, defaults to true
+ *   - [ident]: string, program name or tag for each log message, defaults to php
  *
  * - swift_mailer:
  *   - from_email: optional if email_prototype is given

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -427,6 +427,7 @@ class MonologExtension extends Extension
                 $handler['facility'],
                 $handler['level'],
                 $handler['bubble'],
+                $handler['ident'],
             ));
             break;
 


### PR DESCRIPTION
The ident is currently missing as a option for the syslogudp handler.