### PR TITLE
Allow setting "ident" parameter for SyslogUdpHandler, affects #266

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -138,6 +138,7 @@ use Monolog\Logger;
  *   - [logopts]: defaults to LOG_PID
  *   - [level]: level name or int value, defaults to DEBUG
  *   - [bubble]: bool, defaults to true
+ *   - [ident]: string, defaults to
  *
  * - swift_mailer:
  *   - from_email: optional if email_prototype is given
@@ -353,7 +354,7 @@ class Configuration implements ConfigurationInterface
                             ->end()
                             ->scalarNode('filename_format')->defaultValue('{filename}-{date}')->end() //rotating
                             ->scalarNode('date_format')->defaultValue('Y-m-d')->end() //rotating
-                            ->scalarNode('ident')->defaultFalse()->end() // syslog
+                            ->scalarNode('ident')->defaultFalse()->end() // syslog and syslogudp
                             ->scalarNode('logopts')->defaultValue(LOG_PID)->end() // syslog
                             ->scalarNode('facility')->defaultValue('user')->end() // syslog
                             ->scalarNode('max_files')->defaultValue(0)->end() // rotating

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -428,6 +428,9 @@ class MonologExtension extends Extension
                 $handler['level'],
                 $handler['bubble'],
             ));
+            if ($handler['ident']) {
+                $definition->addArgument($handler['ident']);
+            }
             break;
 
         case 'swift_mailer':


### PR DESCRIPTION
As outlined in ticket #266:

The SyslogUdpHandler constructor has a sixth parameter "ident", defaulting to "php".
However, the current Monolog Bundle implementation allows setting only the first five. Which defaults to the "ident" being set to "php".
In our case, we are using papertrail as a log backend, and use the same webserver for multiple small projects. In papertrail, that results in the following output:

```
May 05 02:16:30 vagrant php:  app.ERROR: fooo {"exception":"[object] (Exception(code: 0): fooo at /var/customers/webs/fastbolt/https/env1.fastbolt.com/src/Pricecalc/UserBundle/Controller/SecurityController.php:36)","username":"anon.","uri":"http://env1.dev.local/login","level":"critical"} []
May 05 02:18:32 vagrant php:  app.ERROR: fooo {"exception":"[object] (Exception(code: 0): fooo at /var/customers/webs/fastbolt/https/env2.fastbolt.com/src/Pricecalc/UserBundle/Controller/SecurityController.php:36)","username":"anon.","uri":"http://env2.dev.local/login","level":"critical"} []
```

The "php" after "vagrant" is the ident configuration. As you can see, we are not able to determine the source environment, other than guessing from filepath or uri.
However, for filtering using the API, we`d like to be able to change the ident per configuration.

```
monolog:
    handlers:
        syslog:
            type: syslogudp
            host: example.com
            port: 514
            level: error
            ident: env1
```

Using that config, we should be able to achieve the following log:

```
May 05 02:16:30 vagrant env1:  app.ERROR: fooo {"exception":"[object] (Exception(code: 0): fooo at /var/customers/webs/fastbolt/https/env1.fastbolt.com/src/Pricecalc/UserBundle/Controller/SecurityController.php:36)","username":"anon.","uri":"http://env1.dev.local/login","level":"critical"} []
May 05 02:18:32 vagrant env2:  app.ERROR: fooo {"exception":"[object] (Exception(code: 0): fooo at /var/customers/webs/fastbolt/https/env2.fastbolt.com/src/Pricecalc/UserBundle/Controller/SecurityController.php:36)","username":"anon.","uri":"http://env2.dev.local/login","level":"critical"} []
```

Please let me know if there is anything else I should do, as that`s my first PR/issue here.