### PR TITLE
Fix the autowiring of the channel logger in autoconfigured services

### DIFF
--- a/DependencyInjection/Compiler/LoggerChannelPass.php
+++ b/DependencyInjection/Compiler/LoggerChannelPass.php
@@ -63,7 +63,7 @@ class LoggerChannelPass implements CompilerPassInterface
                 }
                 $definition->setMethodCalls($calls);
 
-                if (!$definition instanceof ChildDefinition && \method_exists($definition, 'getBindings')) {
+                if (\method_exists($definition, 'getBindings')) {
                     $binding = new BoundArgument(new Reference($loggerId));
 
                     // Mark the binding as used already, to avoid reporting it as unused if the service does not use a

--- a/Tests/DependencyInjection/Compiler/LoggerChannelPassTest.php
+++ b/Tests/DependencyInjection/Compiler/LoggerChannelPassTest.php
@@ -82,6 +82,28 @@ class LoggerChannelPassTest extends TestCase
         $this->assertEquals('monolog.logger.test', (string) $dummyService->getArgument(0));
     }
 
+    public function testAutowiredLoggerArgumentsAreReplacedWithChannelLoggerWhenAutoconfigured()
+    {
+        if (!\method_exists('Symfony\Component\DependencyInjection\Definition', 'getBindings')) {
+            $this->markTestSkipped('Need DependencyInjection 3.4+ to autowire channel logger.');
+        }
+
+        $container = $this->getFunctionalContainer();
+
+        $container->registerForAutoconfiguration('Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Compiler\DummyService')
+            ->setProperty('fake', 'dummy');
+
+        $container->register('dummy_service', 'Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Compiler\DummyService')
+            ->setAutowired(true)
+            ->setAutoconfigured(true)
+            ->setPublic(true)
+            ->addTag('monolog.logger', array('channel' => 'test'));
+
+        $container->compile();
+
+        $this->assertEquals('monolog.logger.test', (string) $container->getDefinition('dummy_service')->getArgument(0));
+    }
+
     public function testAutowiredLoggerArgumentsAreNotReplacedWithChannelLoggerIfLoggerArgumentIsConfiguredExplicitly()
     {
         if (!\method_exists('Symfony\Component\DependencyInjection\Definition', 'getBindings')) {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.6",
         "symfony/monolog-bridge": "~2.7|~3.3|~4.0",
-        "symfony/dependency-injection": "~2.7|~3.3|~4.0",
+        "symfony/dependency-injection": "~2.7|~3.4.10|^4.0.10",
         "symfony/config": "~2.7|~3.3|~4.0",
         "symfony/http-kernel": "~2.7|~3.3|~4.0",
         "monolog/monolog": "~1.22"


### PR DESCRIPTION
This depends on https://github.com/symfony/symfony/pull/27271, hence the new min version of the DI component