### PR TITLE
Support environment option for raven client

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -558,6 +558,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('client_id')->defaultNull()->end() // raven_handler
                             ->scalarNode('auto_log_stacks')->defaultFalse()->end() // raven_handler
                             ->scalarNode('release')->defaultNull()->end() // raven_handler
+                            ->scalarNode('environment')->defaultNull()->end() // raven_handler
                             ->scalarNode('message_type')->defaultValue(0)->end() // error_log
                             ->arrayNode('tags') // loggly
                                 ->beforeNormalization()

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -605,7 +605,10 @@ class MonologExtension extends Extension
             } else {
                 $client = new Definition('Raven_Client', array(
                     $handler['dsn'],
-                    array('auto_log_stacks' => $handler['auto_log_stacks'])
+                    array(
+                        'auto_log_stacks' => $handler['auto_log_stacks'],
+                        'environment' => $handler['environment']
+                    )
                 ));
                 $client->setPublic(false);
                 $clientId = 'monolog.raven.client.'.sha1($handler['dsn']);


### PR DESCRIPTION
In sentry 9, we can filter logs thourgh environments. This PR allows to support this option.