### PR TITLE
Deprecrate "excluded_404s" option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Added timeouts to the pushover, hipchat, slack handlers
 * Dropped support for PHP 5.3, 5.4, and HHVM
 * Added configuration for HttpCodeActivationStrategy
+* Deprecated "excluded_404s" option for Symfony >= 3.4
 
 ## 3.2.0 (2018-03-05)
 

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\MonologBundle\DependencyInjection;
 
+use Symfony\Bridge\Monolog\Handler\FingersCrossed\HttpCodeActivationStrategy;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -317,6 +318,9 @@ class MonologExtension extends Extension
             if (isset($handler['activation_strategy'])) {
                 $activation = new Reference($handler['activation_strategy']);
             } elseif (!empty($handler['excluded_404s'])) {
+                if (class_exists(HttpCodeActivationStrategy::class)) {
+                    @trigger_error('The "excluded_404s" option is deprecated in MonologBundle since version 3.4.0, you should rely on the "excluded_http_codes" option instead.', E_USER_DEPRECATED);
+                }
                 $activationDef = new Definition('Symfony\Bridge\Monolog\Handler\FingersCrossed\NotFoundActivationStrategy', array(
                     new Reference('request_stack'),
                     $handler['excluded_404s'],


### PR DESCRIPTION
Hello,

Just saw this issue https://github.com/symfony/symfony/issues/26969 and decided to do something about it.

I need to fix the `MonologExtensionTest::testFingersCrossedHandlerWhenExcluded404sAreSpecified` test but I don't really how to proceed, any feedbacks are welcomed :)