### PR TITLE
Allow marking service handlers as nested

### DIFF
--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -131,6 +131,10 @@ class MonologExtension extends Extension
         if ('service' === $handler['type']) {
             $container->setAlias($handlerId, $handler['id']);
 
+            if (!empty($handler['nested']) && true === $handler['nested']) {
+                $this->markNestedHandler($handlerId);
+            }
+
             return $handlerId;
         }
 


### PR DESCRIPTION
Due to the early handling of `service` handlers in the extension, a service handler can't be marked as nested using the `nested` configuration option. This can cause issues when declaring multiple (nested) handlers of which one is then chosen based on the environment: since the service handler can't explicitly be marked as nested, it will always pushed to the logger even when it shouldn't be used.