### PR TITLE
Flush loggers on kernel.reset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ matrix:
     - php: 7.0
     - php: 7.1
     - php: 7.2
+    - php: 7.3
     # Test against dev versions
     - php: nightly
       env: DEPENDENCIES=dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 3.3.2 (2018-12-29)
+
+* Fixed psr-3 processing being applied to all handlers, only leaf ones are now processing
+* Fixed regression when `app` channel is defined explicitly
+* Fixed handlers marked as nested not being ignored properly from the stack
+
+## 3.3.1 (2018-11-04)
+
+* Fixed compatiblity with Symfony 4.2
+
 ## 3.3.0 (2018-06-04)
 
 * Fixed the autowiring of the channel logger in autoconfigured services

--- a/DependencyInjection/Compiler/LoggerChannelPass.php
+++ b/DependencyInjection/Compiler/LoggerChannelPass.php
@@ -81,6 +81,9 @@ class LoggerChannelPass implements CompilerPassInterface
 
         // create additional channels
         foreach ($container->getParameter('monolog.additional_channels') as $chan) {
+            if ($chan === 'app') {
+                continue;
+            }
             $loggerId = sprintf('monolog.logger.%s', $chan);
             $this->createLogger($chan, $loggerId, $container);
             $container->getDefinition($loggerId)->setPublic(true);

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -293,6 +293,8 @@ use Monolog\Logger;
  *   - [level]: level name or int value, defaults to DEBUG
  *   - [bubble]: bool, defaults to true
  *
+ * All handlers can also be marked with `nested: true` to make sure they are never added explicitly to the stack
+ *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  * @author Christophe Coevoet <stof@notk.org>
  */
@@ -305,8 +307,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('monolog');
+        $treeBuilder = new TreeBuilder('monolog');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('monolog');
 
         $rootNode
             ->fixXmlConfig('channel')
@@ -342,7 +344,7 @@ class Configuration implements ConfigurationInterface
                             ->booleanNode('bubble')->defaultTrue()->end()
                             ->scalarNode('app_name')->defaultNull()->end()
                             ->booleanNode('include_stacktraces')->defaultFalse()->end()
-                            ->booleanNode('process_psr_3_messages')->defaultTrue()->end()
+                            ->booleanNode('process_psr_3_messages')->defaultNull()->end()
                             ->scalarNode('path')->defaultValue('%kernel.logs_dir%/%kernel.environment%.log')->end() // stream and rotating
                             ->scalarNode('file_permission')  // stream and rotating
                                 ->defaultNull()
@@ -707,6 +709,10 @@ class Configuration implements ConfigurationInterface
                         ->validate()
                             ->ifTrue(function ($v) { return 'fingers_crossed' === $v['type'] && !empty($v['excluded_http_codes']) && !empty($v['excluded_404s']); })
                             ->thenInvalid('You can not use excluded_http_codes together with excluded_404s in a FingersCrossedHandler')
+                        ->end()
+                        ->validate()
+                            ->ifTrue(function ($v) { return 'fingers_crossed' !== $v['type'] && (!empty($v['excluded_http_codes']) || !empty($v['excluded_404s'])); })
+                            ->thenInvalid('You can only use excluded_http_codes/excluded_404s with a FingersCrossedHandler definition')
                         ->end()
                         ->validate()
                             ->ifTrue(function ($v) { return 'filter' === $v['type'] && "DEBUG" !== $v['min_level'] && !empty($v['accepted_levels']); })

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004-2012 Fabien Potencier
+Copyright (c) 2004-2019 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Tests/DependencyInjection/Compiler/LoggerChannelPassTest.php
+++ b/Tests/DependencyInjection/Compiler/LoggerChannelPassTest.php
@@ -134,6 +134,14 @@ class LoggerChannelPassTest extends TestCase
         $this->assertEquals(array(), $dummyService->getArguments());
     }
 
+    public function testChannelsConfigurationOptionSupportsAppChannel()
+    {
+        $container = $this->getFunctionalContainer();
+
+        $container->setParameter('monolog.additional_channels', array('app'));
+        $container->compile();
+    }
+
     private function getContainer()
     {
         $container = new ContainerBuilder();
@@ -202,6 +210,9 @@ class LoggerChannelPassTest extends TestCase
         return $container;
     }
 
+    /**
+     * @return ContainerBuilder
+     */
     private function getFunctionalContainer()
     {
         $container = new ContainerBuilder();

--- a/Tests/DependencyInjection/FixtureMonologExtensionTest.php
+++ b/Tests/DependencyInjection/FixtureMonologExtensionTest.php
@@ -202,7 +202,7 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
 
         $methodCalls = $logger->getMethodCalls();
 
-        $this->assertContains(array('pushProcessor', array(new Reference('monolog.processor.psr_log_message'))), $methodCalls, 'The PSR-3 processor should not be enabled', false, false);
+        $this->assertContains(array('pushProcessor', array(new Reference('monolog.processor.psr_log_message'))), $methodCalls, 'The PSR-3 processor should be enabled', false, false);
     }
 
     public function testPsr3MessageProcessingDisabled()

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "symfony/yaml": "~2.7|~3.3|~4.0",
         "symfony/console": "~2.7|~3.3|~4.0",
-        "symfony/phpunit-bridge": "^3.3|^4.0"
+        "symfony/phpunit-bridge": "^3.4.19|^4.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bundle\\MonologBundle\\": "" },


### PR DESCRIPTION
Fixes https://github.com/php-pm/php-pm-httpkernel/issues/134 and https://github.com/php-pm/php-pm-httpkernel/issues/62

When using [PHP-PM](https://github.com/php-pm/php-pm) the worker does not die at the end of the request, so the shutdown functions registered by monolog are never triggered (so for example `BufferHandler` never flushes). This PR partially fixes the problem by flushing the loggers containing a `flush` function at the end of each request.

I did not use the `close` function (mentioned in https://github.com/Seldaek/monolog/issues/1053) because some loggers use sockets or other connections that would be closed in this case and not be reusable in the next request.

I'm not sure if this is the best solution to this problem, happy to discuss alternatives if there is a better way.