### PR TITLE
Register processors for autoconfiguration

### DIFF
--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Bundle\MonologBundle\DependencyInjection;
 
+use Monolog\Processor\ProcessorInterface;
+use Symfony\Bridge\Monolog\Processor\TokenProcessor;
+use Symfony\Bridge\Monolog\Processor\WebProcessor;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -108,6 +111,18 @@ class MonologExtension extends Extension
         }
 
         $container->setParameter('monolog.additional_channels', isset($config['channels']) ? $config['channels'] : array());
+
+        if (method_exists($container, 'registerForAutoconfiguration')) {
+            if (interface_exists(ProcessorInterface::class)) {
+                $container->registerForAutoconfiguration(ProcessorInterface::class)
+                    ->addTag('monolog.processor');
+            } else {
+                $container->registerForAutoconfiguration(WebProcessor::class)
+                    ->addTag('monolog.processor');
+            }
+            $container->registerForAutoconfiguration(TokenProcessor::class)
+                ->addTag('monolog.processor');
+        }
     }
 
     /**


### PR DESCRIPTION
Replaces https://github.com/symfony/symfony/pull/27801 (which has been reverted meanwhile)
Leverages https://github.com/Seldaek/monolog/pull/1204
Already documented in https://github.com/symfony/symfony-docs/pull/9996 (but doc needs update)