### PR TITLE
Enable the usage of environment variables for log levels.

### DIFF
--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -32,7 +32,7 @@ class MonologExtension extends Extension
 
     private function levelToMonologConst($level)
     {
-        return is_int($level) ? $level : constant('Monolog\Logger::'.strtoupper($level));
+        return \Monolog\Logger::toMonologLevel($level);
     }
 
     /**

--- a/Tests/DependencyInjection/MonologExtensionTest.php
+++ b/Tests/DependencyInjection/MonologExtensionTest.php
@@ -89,6 +89,16 @@ class MonologExtensionTest extends DependencyInjectionTest
         $this->assertDICConstructorArguments($handler, array('foo', false));
     }
 
+    public function testEnvironmentVariablesAsLogLevel()
+    {
+        $container = $this->getContainer(array(array('handlers' => array('main' => array('type' => 'stream', 'level' => '%env(DUMMY_ENV_LOG_LEVEL)%')))));
+        $this->assertTrue($container->hasDefinition('monolog.logger'));
+        $this->assertTrue($container->hasDefinition('monolog.handler.main'));
+
+        $handler = $container->getDefinition('monolog.handler.main');
+        $this->assertDICConstructorArguments($handler, array('%kernel.logs_dir%/%kernel.environment%.log', '%env(DUMMY_ENV_LOG_LEVEL)%', true, null));
+    }
+
     /**
      * @expectedException InvalidArgumentException
      */


### PR DESCRIPTION
This is an solution for #220. It's an alternative to #245 which solves the issue as well but is in my opinion is a bit too rigid/heavy.

This PR modifies the `levelToMonologConst` function to call` \Monolog\Logger::toMonologLevel()` which almost does does the same, but keeps the argument as is without changing it to `NULL` when it does not match a log constant. This way it will be possible to use environment variables as log levels.

For clarity, the \Monolog\Logger::toMonologLevel() functions looks like this:

    public static function toMonologLevel($level)
    {
        if (is_string($level) && defined(__CLASS__.'::'.strtoupper($level))) {
            return constant(__CLASS__.'::'.strtoupper($level));
        }

        return $level;
    }

It will be breaking for those who rely on specifying an invalid level being converted to `NULL`.

Fixes #220
