### PR TITLE
Expose configuration for the ConsoleHandler

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -36,6 +36,7 @@ use Monolog\Logger;
  *   - [verbosity_levels]: level => verbosity configuration
  *   - [level]: level name or int value, defaults to DEBUG
  *   - [bubble]: bool, defaults to true
+ *   - [console_formater_options]: array
  *
  * - firephp:
  *   - [level]: level name or int value, defaults to DEBUG
@@ -571,6 +572,16 @@ class Configuration implements ConfigurationInterface
                                     ->then(function ($v) { return array_filter(array_map('trim', $v)); })
                                 ->end()
                                 ->prototype('scalar')->end()
+                            ->end()
+                             // console
+                            ->variableNode('console_formater_options')
+                                ->defaultValue([])
+                                ->validate()
+                                    ->ifTrue(function ($v) {
+                                        return !is_array($v);
+                                    })
+                                    ->thenInvalid('console_formater_options must an array.')
+                                ->end()
                             ->end()
                             ->arrayNode('verbosity_levels') // console
                                 ->beforeNormalization()

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -176,6 +176,7 @@ class MonologExtension extends Extension
                 null,
                 $handler['bubble'],
                 isset($handler['verbosity_levels']) ? $handler['verbosity_levels'] : array(),
+                $handler['console_formater_options']
             ));
             $definition->addTag('kernel.event_subscriber');
             break;


### PR DESCRIPTION
Like that we will be able to use this configuration (for example):
```yaml
        console:
            type: console
            process_psr_3_messages: false
            channels: ["!event", "!doctrine", "!console"]
            console_formater_options:
                format: "%%datetime%% %%start_tag%%%%level_name%%%%end_tag%% <comment>[%%channel%%]</> %%message%%%%context%%\n"
                multiline: false
```

see also https://github.com/symfony/symfony/pull/30345