### PR TITLE
Deprecate "excluded_404s" option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.4.0 (xxxx-xx-xx)
 
+* Deprecate "excluded_404s" option
 * Flush loggers on `kernel.reset`
 * Register processors (`ProcessorInterface`) for autoconfiguration (tag: `monolog.processor`)
 * Expose configuration for the `ConsoleHandler`
@@ -17,6 +18,7 @@
 * Added timeouts to the pushover, hipchat, slack handlers
 * Dropped support for PHP 5.3, 5.4, and HHVM
 * Added configuration for HttpCodeActivationStrategy
+* Deprecated "excluded_404s" option for Symfony >= 3.4
 
 ## 3.2.0 (2018-03-05)
 

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\MonologBundle\DependencyInjection;
 
 use Monolog\Processor\ProcessorInterface;
 use Monolog\ResettableInterface;
+use Symfony\Bridge\Monolog\Handler\FingersCrossed\HttpCodeActivationStrategy;
 use Symfony\Bridge\Monolog\Processor\TokenProcessor;
 use Symfony\Bridge\Monolog\Processor\WebProcessor;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -343,6 +344,9 @@ class MonologExtension extends Extension
             if (isset($handler['activation_strategy'])) {
                 $activation = new Reference($handler['activation_strategy']);
             } elseif (!empty($handler['excluded_404s'])) {
+                if (class_exists(HttpCodeActivationStrategy::class)) {
+                    @trigger_error('The "excluded_404s" option is deprecated in MonologBundle since version 3.4.0, you should rely on the "excluded_http_codes" option instead.', E_USER_DEPRECATED);
+                }
                 $activationDef = new Definition('Symfony\Bridge\Monolog\Handler\FingersCrossed\NotFoundActivationStrategy', array(
                     new Reference('request_stack'),
                     $handler['excluded_404s'],

--- a/Tests/DependencyInjection/MonologExtensionTest.php
+++ b/Tests/DependencyInjection/MonologExtensionTest.php
@@ -383,6 +383,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         $this->assertDICDefinitionMethodCallAt(1, $handler, 'setTag', array('foo,bar'));
     }
 
+    /** @group legacy */
     public function testFingersCrossedHandlerWhenExcluded404sAreSpecified()
     {
         $container = $this->getContainer(array(array('handlers' => array(


### PR DESCRIPTION
replaces #275
fixed https://github.com/symfony/symfony/issues/26969

I have fixed confliects + CS + updated the CHANGELOG