### PR TITLE
Add support for headers in native mailer

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -175,6 +175,7 @@ use Monolog\Logger;
  *   - subject: string
  *   - [level]: level name or int value, defaults to DEBUG
  *   - [bubble]: bool, defaults to true
+ *   - [headers]: optional array containing additional headers
  *
  * - socket:
  *   - connection_string: string
@@ -594,6 +595,10 @@ class Configuration implements ConfigurationInterface
                             ->end()
                             ->scalarNode('subject')->end() // swift_mailer and native_mailer
                             ->scalarNode('content_type')->defaultNull()->end() // swift_mailer
+                            ->arrayNode('headers') // native_mailer
+                                ->canBeUnset()
+                                ->scalarPrototype()->end()
+                            ->end()
                             ->scalarNode('mailer')->defaultValue('mailer')->end() // swift_mailer
                             ->arrayNode('email_prototype') // swift_mailer
                                 ->canBeUnset()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -175,7 +175,7 @@ use Monolog\Logger;
  *   - subject: string
  *   - [level]: level name or int value, defaults to DEBUG
  *   - [bubble]: bool, defaults to true
- *   - [headers]: optional array containing additional headers
+ *   - [headers]: optional array containing additional headers: ['Foo: Bar', '...']
  *
  * - socket:
  *   - connection_string: string
@@ -348,6 +348,7 @@ class Configuration implements ConfigurationInterface
                         ->fixXmlConfig('excluded_http_code')
                         ->fixXmlConfig('tag')
                         ->fixXmlConfig('accepted_level')
+                        ->fixXmlConfig('header')
                         ->canBeUnset()
                         ->children()
                             ->scalarNode('type')

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -541,7 +541,7 @@ class MonologExtension extends Extension
                 $handler['bubble'],
             ));
             if (!empty($handler['headers'])) {
-                $definition->addMethodCall('addHeader', $handler['headers']);
+                $definition->addMethodCall('addHeader', [$handler['headers']]);
             }
             break;
 

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -540,6 +540,9 @@ class MonologExtension extends Extension
                 $handler['level'],
                 $handler['bubble'],
             ));
+            if (!empty($handler['headers'])) {
+                $definition->addMethodCall('addHeader', $handler['headers']);
+            }
             break;
 
         case 'socket':

--- a/Resources/config/schema/monolog-1.0.xsd
+++ b/Resources/config/schema/monolog-1.0.xsd
@@ -88,6 +88,7 @@
         <xsd:attribute name="content-type" type="xsd:string" />
         <xsd:attribute name="webhook-url" type="xsd:string" />
         <xsd:attribute name="slack-team" type="xsd:string" />
+        <xsd:attribute name="headers" type="headers" />
     </xsd:complexType>
 
     <xsd:simpleType name="level">
@@ -185,5 +186,11 @@
             <xsd:element name="url" type="xsd:string" />
         </xsd:choice>
         <xsd:attribute name="code" type="xsd:integer" />
+    </xsd:complexType>
+
+    <xsd:complexType name="headers">
+        <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:element name="header" type="xsd:string" />
+        </xsd:choice>
     </xsd:complexType>
 </xsd:schema>

--- a/Resources/config/schema/monolog-1.0.xsd
+++ b/Resources/config/schema/monolog-1.0.xsd
@@ -28,6 +28,7 @@
             <xsd:element name="tag" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="accepted-level" type="level" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="to-email" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="header" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
         </xsd:sequence>
         <xsd:attribute name="type" type="xsd:string" />
         <xsd:attribute name="priority" type="xsd:integer" />
@@ -88,7 +89,6 @@
         <xsd:attribute name="content-type" type="xsd:string" />
         <xsd:attribute name="webhook-url" type="xsd:string" />
         <xsd:attribute name="slack-team" type="xsd:string" />
-        <xsd:attribute name="headers" type="headers" />
     </xsd:complexType>
 
     <xsd:simpleType name="level">
@@ -189,8 +189,8 @@
     </xsd:complexType>
 
     <xsd:complexType name="headers">
-        <xsd:choice minOccurs="0" maxOccurs="unbounded">
-            <xsd:element name="header" type="xsd:string" />
-        </xsd:choice>
+        <xsd:sequence>
+            <xsd:any minOccurs="0" processContents="lax"/>
+        </xsd:sequence>
     </xsd:complexType>
 </xsd:schema>

--- a/Tests/DependencyInjection/FixtureMonologExtensionTest.php
+++ b/Tests/DependencyInjection/FixtureMonologExtensionTest.php
@@ -216,6 +216,17 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
         $this->assertNotContains(array('pushProcessor', array(new Reference('monolog.processor.psr_log_message'))), $methodCalls, 'The PSR-3 processor should not be enabled', false, false);
     }
 
+    public function testNativeMailer()
+    {
+        $container = $this->getContainer('native_mailer');
+
+        $logger = $container->getDefinition('monolog.handler.mailer');
+        $methodCalls = $logger->getMethodCalls();
+
+        $this->assertCount(2, $methodCalls);
+        $this->assertSame(['addHeader', [['Foo: bar', 'Baz: inga']]], $methodCalls[1]);
+    }
+
     protected function getContainer($fixture)
     {
         $container = new ContainerBuilder();

--- a/Tests/DependencyInjection/Fixtures/xml/native_mailer.xml
+++ b/Tests/DependencyInjection/Fixtures/xml/native_mailer.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+
+<srv:container xmlns="http://symfony.com/schema/dic/monolog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:srv="http://symfony.com/schema/dic/services"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/monolog http://symfony.com/schema/dic/monolog/monolog-1.0.xsd">
+
+    <config>
+        <handler name="mailer" type="native_mailer" to-email="foo@example.com" from-email="bar@example.com" subject="a subject">
+            <header>Foo: bar</header>
+            <header>Baz: inga</header>
+        </handler>
+    </config>
+</srv:container>

--- a/Tests/DependencyInjection/Fixtures/yml/native_mailer.yml
+++ b/Tests/DependencyInjection/Fixtures/yml/native_mailer.yml
@@ -1,0 +1,10 @@
+monolog:
+    handlers:
+        mailer:
+            type: native_mailer
+            from_email: foo@example.com
+            to_email: bar@exemple.com
+            subject: a subject
+            headers:
+                - "Foo: bar"
+                - "Baz: inga"


### PR DESCRIPTION
The native mailer is able to have additional headers, but it
wasn't possible to give it any headers in the configuration.
Swift mailer may have a content_type key but not native mailer.

A new "headers" key is now allowed in the handler configuration, so a
list of headers may be given to the handler. Only native mailer supports
it.

Related to #272