### PR TITLE
Update Configuration Documentation for Elasticsearch

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -81,7 +81,7 @@ use Monolog\Logger;
  * - elasticsearch:
  *   - elasticsearch:
  *      - id: optional if host is given
- *      - host: elastic search host name
+ *      - host: elastic search host name. Do not prepend with http(s)://
  *      - [port]: defaults to 9200
  *   - [index]: index name, defaults to monolog
  *   - [document_type]: document_type, defaults to logs


### PR DESCRIPTION
Related to #296 

Elasticsearch host must not have (http://) or (https://) in the configuration, just the IP or the domain name.

Otherwise an error is thrown that there is `No enabled connection`