### PR TITLE
#310 : Add sentry 2.0 type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 3.5.0 (xxxx-xx-xx)
 
+* Add `sentry` type to use sentry 2.0 client
+
 ## 3.4.0 (2019-06-20)
 
 * Deprecate "excluded_404s" option

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -194,13 +194,14 @@ use Monolog\Logger;
  *   - [timeout]: float
  *   - [connection_timeout]: float
  *
- * - raven:
+ * - raven / sentry:
  *   - dsn: connection string
  *   - client_id: Raven client custom service id (optional)
  *   - [release]: release number of the application that will be attached to logs, defaults to null
  *   - [level]: level name or int value, defaults to DEBUG
  *   - [bubble]: bool, defaults to true
  *   - [auto_log_stacks]: bool, defaults to false
+ *   - [environment]: string, default to null (no env specified)
  *
  * - newrelic:
  *   - [level]: level name or int value, defaults to DEBUG
@@ -620,11 +621,11 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('store')->defaultNull()->end() // deduplication
                             ->scalarNode('connection_timeout')->end() // socket_handler, logentries, pushover, hipchat & slack
                             ->booleanNode('persistent')->end() // socket_handler
-                            ->scalarNode('dsn')->end() // raven_handler
-                            ->scalarNode('client_id')->defaultNull()->end() // raven_handler
+                            ->scalarNode('dsn')->end() // raven_handler, sentry_handler
+                            ->scalarNode('client_id')->defaultNull()->end() // raven_handler, sentry_handler
                             ->scalarNode('auto_log_stacks')->defaultFalse()->end() // raven_handler
-                            ->scalarNode('release')->defaultNull()->end() // raven_handler
-                            ->scalarNode('environment')->defaultNull()->end() // raven_handler
+                            ->scalarNode('release')->defaultNull()->end() // raven_handler, sentry_handler
+                            ->scalarNode('environment')->defaultNull()->end() // raven_handler, sentry_handler
                             ->scalarNode('message_type')->defaultValue(0)->end() // error_log
                             ->arrayNode('tags') // loggly
                                 ->beforeNormalization()
@@ -836,6 +837,10 @@ class Configuration implements ConfigurationInterface
                         ->validate()
                             ->ifTrue(function ($v) { return 'raven' === $v['type'] && !array_key_exists('dsn', $v) && null === $v['client_id']; })
                             ->thenInvalid('The DSN has to be specified to use a RavenHandler')
+                        ->end()
+                        ->validate()
+                            ->ifTrue(function ($v) { return 'sentry' === $v['type'] && !array_key_exists('dsn', $v) && null === $v['client_id']; })
+                            ->thenInvalid('The DSN has to be specified to use Sentry\'s handler')
                         ->end()
                         ->validate()
                             ->ifTrue(function ($v) { return 'hipchat' === $v['type'] && (empty($v['token']) || empty($v['room'])); })


### PR DESCRIPTION
As said on #310, sentry completely changed their API and even stopped calling their client "raven", using now php-http to handle the requests to their api.

So this PR adds a new type in the config to support the handler they made.

I'm not sure on a few points (such as the self-referencing hub, which I commented because otherwise it would go on an infinite recursion problem), and I based the service definition on [sentry's bundle](https://github.com/getsentry/sentry-symfony).

Poke @Jean85 maybe, as he is maintaining (as far as I can tell ?) the current sentry bundle.

Fixes #310 