### PR TITLE
Allow Symfony 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,16 +17,16 @@
     ],
     "require": {
         "php": ">=5.6",
-        "symfony/monolog-bridge": "~3.4|~4.0",
-        "symfony/dependency-injection": "~3.4.10|^4.0.10",
-        "symfony/config": "~3.4|~4.0",
-        "symfony/http-kernel": "~3.4|~4.0",
+        "symfony/monolog-bridge": "~3.4 || ~4.0 || ^5.0",
+        "symfony/dependency-injection": "~3.4.10 || ^4.0.10 || ^5.0",
+        "symfony/config": "~3.4 || ~4.0 || ^5.0",
+        "symfony/http-kernel": "~3.4 || ~4.0 || ^5.0",
         "monolog/monolog": "~1.22"
     },
     "require-dev": {
-        "symfony/yaml": "~3.4|~4.0",
-        "symfony/console": "~3.4|~4.0",
-        "symfony/phpunit-bridge": "^3.4.19|^4.0"
+        "symfony/yaml": "~3.4 || ~4.0 || ^5.0",
+        "symfony/console": "~3.4 || ~4.0 || ^5.0",
+        "symfony/phpunit-bridge": "^3.4.19 || ^4.0 || ^5.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bundle\\MonologBundle\\": "" },


### PR DESCRIPTION
Well, symfony 5 is around the corner, so let's allow it (especially as the master of the skeleton targets 5.0 now)