### PR TITLE
Symfony autowiring monolog channels #278

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.5.0 (xxxx-xx-xx)
 
 * Add `sentry` type to use sentry 2.0 client
+* Added possibility for auto-wire monolog channel according to the type-hinted aliases, introduced in the Symfony 4.2
 
 ## 3.4.0 (2019-06-20)
 

--- a/DependencyInjection/Compiler/LoggerChannelPass.php
+++ b/DependencyInjection/Compiler/LoggerChannelPass.php
@@ -135,7 +135,7 @@ class LoggerChannelPass implements CompilerPassInterface
     }
 
     /**
-     * Create new logger from th monolog.logger_prototype
+     * Create new logger from the monolog.logger_prototype
      *
      * @param string $channel
      * @param string $loggerId

--- a/DependencyInjection/Compiler/LoggerChannelPass.php
+++ b/DependencyInjection/Compiler/LoggerChannelPass.php
@@ -152,7 +152,9 @@ class LoggerChannelPass implements CompilerPassInterface
 
         // Allows only for Symfony 4.2+
         if (\method_exists($container, 'registerAliasForArgument')) {
-            $container->registerAliasForArgument($loggerId, LoggerInterface::class);
+            $parameterName = $channel . 'Logger';
+
+            $container->registerAliasForArgument($loggerId, LoggerInterface::class, $parameterName);
         }
     }
 

--- a/Tests/DependencyInjection/Compiler/LoggerChannelPassTest.php
+++ b/Tests/DependencyInjection/Compiler/LoggerChannelPassTest.php
@@ -53,6 +53,7 @@ class LoggerChannelPassTest extends TestCase
 
         $this->assertNotNull($container->getDefinition('monolog.logger.additional'));
 
+        // test below acceptable only for Symfony 4.2+
         if (!\method_exists(ContainerBuilder::class, 'registerAliasForArgument')) {
             return;
         }
@@ -61,7 +62,7 @@ class LoggerChannelPassTest extends TestCase
         $expectedChannels[] = 'additional';
 
         foreach ($expectedChannels as $channelName) {
-            $aliasName = LoggerInterface::class.' $monologLogger'.\ucfirst($channelName);
+            $aliasName = LoggerInterface::class.' $' .$channelName.'Logger';
             $this->assertTrue($container->hasAlias($aliasName), 'type-hinted alias should be exists for each logger channel');
         }
     }

--- a/Tests/DependencyInjection/Compiler/LoggerChannelPassTest.php
+++ b/Tests/DependencyInjection/Compiler/LoggerChannelPassTest.php
@@ -61,7 +61,7 @@ class LoggerChannelPassTest extends TestCase
         }
 
         $container = $this->getContainer();
-        $expectedChannels = array('test', 'foo', 'bar', 'additional');
+        $expectedChannels = ['test', 'foo', 'bar', 'additional'];
 
         foreach ($expectedChannels as $channelName) {
             $aliasName = LoggerInterface::class.' $' .$channelName.'Logger';

--- a/Tests/DependencyInjection/Compiler/LoggerChannelPassTest.php
+++ b/Tests/DependencyInjection/Compiler/LoggerChannelPassTest.php
@@ -52,14 +52,16 @@ class LoggerChannelPassTest extends TestCase
         }
 
         $this->assertNotNull($container->getDefinition('monolog.logger.additional'));
+    }
 
-        // test below acceptable only for Symfony 4.2+
+    public function testTypeHintedAliasesExistForEachChannel()
+    {
         if (!\method_exists(ContainerBuilder::class, 'registerAliasForArgument')) {
-            return;
+            $this->markTestSkipped('Need DependencyInjection 4.2+ to register type-hinted aliases for channels.');
         }
 
-        $expectedChannels = \array_keys($expected);
-        $expectedChannels[] = 'additional';
+        $container = $this->getContainer();
+        $expectedChannels = array('test', 'foo', 'bar', 'additional');
 
         foreach ($expectedChannels as $channelName) {
             $aliasName = LoggerInterface::class.' $' .$channelName.'Logger';

--- a/Tests/DependencyInjection/Compiler/LoggerChannelPassTest.php
+++ b/Tests/DependencyInjection/Compiler/LoggerChannelPassTest.php
@@ -13,12 +13,12 @@ namespace Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\DependencyInjection\Definition;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\LoggerChannelPass;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
 
 class LoggerChannelPassTest extends TestCase
 {
@@ -51,7 +51,19 @@ class LoggerChannelPassTest extends TestCase
             }
         }
 
-        $this->assertNotNull($container->getDefinition('monolog.logger.manualchan'));
+        $this->assertNotNull($container->getDefinition('monolog.logger.additional'));
+
+        if (!\method_exists(ContainerBuilder::class, 'registerAliasForArgument')) {
+            return;
+        }
+
+        $expectedChannels = \array_keys($expected);
+        $expectedChannels[] = 'additional';
+
+        foreach ($expectedChannels as $channelName) {
+            $aliasName = LoggerInterface::class.' $monologLogger'.\ucfirst($channelName);
+            $this->assertTrue($container->hasAlias($aliasName), 'type-hinted alias should be exists for each logger channel');
+        }
     }
 
     public function testProcessSetters()
@@ -166,7 +178,7 @@ class LoggerChannelPassTest extends TestCase
             $container->setDefinition($name, $service);
         }
 
-        $container->setParameter('monolog.additional_channels', array('manualchan'));
+        $container->setParameter('monolog.additional_channels', array('additional'));
         $container->setParameter('monolog.handlers_to_channels', array(
             'monolog.handler.a' => array(
                 'type' => 'inclusive',
@@ -202,7 +214,7 @@ class LoggerChannelPassTest extends TestCase
         $service->addMethodCall('setLogger', array(new Reference('logger')));
         $container->setDefinition('foo', $service);
 
-        $container->setParameter('monolog.additional_channels', array('manualchan'));
+        $container->setParameter('monolog.additional_channels', array('additional'));
         $container->setParameter('monolog.handlers_to_channels', array());
 
         $container->getCompilerPassConfig()->setOptimizationPasses(array());


### PR DESCRIPTION
resolved #278
- Added possibility for auto-wire monolog channels according to variable type-hint and name.
  Variable will have appropriated name to camel cased monolog channel service name: `monolog.logger.acme -> $acmeLogger`.
- Removed useless import `DefinitionDecorator`.
- Renamed additional channel in the tests from `manualchan` to `additional`