### PR TITLE
[RFC] Bump php requirement 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor
 composer.phar
 composer.lock
 phpunit.xml
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,30 +11,28 @@ cache:
 env:
     global:
         - SYMFONY_PHPUNIT_DIR=.phpunit
+        - SYMFONY_PHPUNIT_VERSION=8.3
 
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
-      env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER=weak
+    - php: '7.1'
+      env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER=weak SYMFONY_PHPUNIT_VERSION=7.5
     # Test against Symfony LTS versions
-    - php: 5.6
-      env: SYMFONY_VERSION="3.4.*"
-    - php: 7.0
-    - php: 7.1
-      # There is a bug in PHPUnit 5.7
-      env: SYMFONY_PHPUNIT_VERSION=6.5
-    - php: 7.2
-    - php: 7.3
+    - php: '7.1'
+      env: SYMFONY_VERSION="3.4.*" SYMFONY_PHPUNIT_VERSION=7.5
+    - php: '7.2'
+    - php: '7.3'
     # Test against dev versions
-    - php: nightly
+    - php: '7.4snapshot'
       env: DEPENDENCIES=dev
   allow_failures:
     - env: DEPENDENCIES=dev
 
 before_install:
     - composer self-update
-    - if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
+    - if [ "$DEPENDENCIES" = "dev" ]; then composer config minimum-stability dev; fi;
+    - if [ "$DEPENDENCIES" = "dev" ]; then pecl install xdebug-beta; fi;
     - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/symfony:"$SYMFONY_VERSION"; fi
 
 install:

--- a/Tests/DependencyInjection/Compiler/AddSwiftMailerTransportPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddSwiftMailerTransportPassTest.php
@@ -26,7 +26,7 @@ class AddSwiftMailerTransportPassTest extends TestCase
 
     private $definition;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->compilerPass = new AddSwiftMailerTransportPass();
         $this->definition = $this->getMockBuilder('\Symfony\Component\DependencyInjection\Definition')->getMock();

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -143,11 +143,10 @@ class ConfigurationTest extends TestCase
         $this->assertEquals('D', $config['handlers']['bar']['channels']['elements'][1]);
     }
 
-    /**
-     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
     public function testInvalidArrays()
     {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+
         $configs = array(
             array(
                 'handlers' => array(
@@ -163,11 +162,10 @@ class ConfigurationTest extends TestCase
         $config = $this->process($configs);
     }
 
-    /**
-     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
     public function testMergingInvalidChannels()
     {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+
         $configs = array(
             array(
                 'handlers' => array(

--- a/Tests/DependencyInjection/MonologExtensionTest.php
+++ b/Tests/DependencyInjection/MonologExtensionTest.php
@@ -114,88 +114,80 @@ class MonologExtensionTest extends DependencyInjectionTest
         $this->assertDICConstructorArguments($handler, array('foo', false));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testExceptionWhenInvalidHandler()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $container = new ContainerBuilder();
         $loader = new MonologExtension();
 
         $loader->load(array(array('handlers' => array('main' => array('type' => 'invalid_handler')))), $container);
     }
 
-    /**
-     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
     public function testExceptionWhenUsingFingerscrossedWithoutHandler()
     {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+
         $container = new ContainerBuilder();
         $loader = new MonologExtension();
 
         $loader->load(array(array('handlers' => array('main' => array('type' => 'fingers_crossed')))), $container);
     }
 
-    /**
-     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
     public function testExceptionWhenUsingFilterWithoutHandler()
     {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+
         $container = new ContainerBuilder();
         $loader = new MonologExtension();
 
         $loader->load(array(array('handlers' => array('main' => array('type' => 'filter')))), $container);
     }
 
-    /**
-     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
     public function testExceptionWhenUsingBufferWithoutHandler()
     {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+
         $container = new ContainerBuilder();
         $loader = new MonologExtension();
 
         $loader->load(array(array('handlers' => array('main' => array('type' => 'buffer')))), $container);
     }
 
-    /**
-     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
     public function testExceptionWhenUsingGelfWithoutPublisher()
     {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+
         $container = new ContainerBuilder();
         $loader = new MonologExtension();
 
         $loader->load(array(array('handlers' => array('gelf' => array('type' => 'gelf')))), $container);
     }
 
-    /**
-     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
     public function testExceptionWhenUsingGelfWithoutPublisherHostname()
     {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+
         $container = new ContainerBuilder();
         $loader = new MonologExtension();
 
         $loader->load(array(array('handlers' => array('gelf' => array('type' => 'gelf', 'publisher' => array())))), $container);
     }
 
-    /**
-     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
     public function testExceptionWhenUsingServiceWithoutId()
     {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+
         $container = new ContainerBuilder();
         $loader = new MonologExtension();
 
         $loader->load(array(array('handlers' => array('main' => array('type' => 'service')))), $container);
     }
 
-    /**
-     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
     public function testExceptionWhenUsingDebugName()
     {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+
         // logger
         $container = new ContainerBuilder();
         $loader = new MonologExtension();

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6",
+        "php": "^7.1.3",
         "symfony/monolog-bridge": "~3.4 || ~4.0 || ^5.0",
         "symfony/dependency-injection": "~3.4.10 || ^4.0.10 || ^5.0",
         "symfony/config": "~3.4 || ~4.0 || ^5.0",


### PR DESCRIPTION
The current master of the bundle aims at becoming compatible with Symfony 5. Although we're still talking about a moving target here, it is very likely that Symfony 5 will add return types to many methods.

A hot candidate would be `ConfigurationInterface::getConfigTreeBuilder()`, a method that this bundle implements. If Symfony 5 adds a return type to that method, this bundle would need to do so as well. That basically means that we would be required to use a syntax element that does not exist in php 5.

I think, this might be the right time to say farewell to php 5 in master. 😃 

This PR bumps the minimal php version to `7.1.3` in order to match the requirements of Symfony 4, but imho we could even be bold here and bump to 7.2.