### PR TITLE
Use short array syntax

### DIFF
--- a/DependencyInjection/Compiler/AddProcessorsPass.php
+++ b/DependencyInjection/Compiler/AddProcessorsPass.php
@@ -47,12 +47,12 @@ class AddProcessorsPass implements CompilerPassInterface
                 }
 
                 if (!empty($tag['method'])) {
-                    $processor = array(new Reference($id), $tag['method']);
+                    $processor = [new Reference($id), $tag['method']];
                 } else {
                     // If no method is defined, fallback to use __invoke
                     $processor = new Reference($id);
                 }
-                $definition->addMethodCall('pushProcessor', array($processor));
+                $definition->addMethodCall('pushProcessor', [$processor]);
             }
         }
     }

--- a/DependencyInjection/Compiler/AddSwiftMailerTransportPass.php
+++ b/DependencyInjection/Compiler/AddSwiftMailerTransportPass.php
@@ -35,18 +35,18 @@ class AddSwiftMailerTransportPass implements CompilerPassInterface
             $mailerId = (string) $definition->getArgument(0);
 
             // Try to fetch the transport for a non-default mailer first, then go with the default swiftmailer
-            $possibleServices = array(
+            $possibleServices = [
                 $mailerId.'.transport.real',
                 $mailerId.'.transport',
                 'swiftmailer.transport.real',
                 'swiftmailer.transport',
-            );
+            ];
 
             foreach ($possibleServices as $serviceId) {
                 if ($container->hasAlias($serviceId) || $container->hasDefinition($serviceId)) {
                     $definition->addMethodCall(
                         'setTransport',
-                        array(new Reference($serviceId))
+                        [new Reference($serviceId)]
                     );
 
                     break;

--- a/DependencyInjection/Compiler/DebugHandlerPass.php
+++ b/DependencyInjection/Compiler/DebugHandlerPass.php
@@ -46,13 +46,13 @@ class DebugHandlerPass implements CompilerPassInterface
             return;
         }
 
-        $debugHandler = new Definition('Symfony\Bridge\Monolog\Handler\DebugHandler', array(Logger::DEBUG, true));
+        $debugHandler = new Definition('Symfony\Bridge\Monolog\Handler\DebugHandler', [Logger::DEBUG, true]);
         $container->setDefinition('monolog.handler.debug', $debugHandler);
 
         foreach ($this->channelPass->getChannels() as $channel) {
             $container
                 ->getDefinition($channel === 'app' ? 'monolog.logger' : 'monolog.logger.'.$channel)
-                ->addMethodCall('pushHandler', array(new Reference('monolog.handler.debug')));
+                ->addMethodCall('pushHandler', [new Reference('monolog.handler.debug')]);
         }
     }
 }

--- a/DependencyInjection/Compiler/FixEmptyLoggerPass.php
+++ b/DependencyInjection/Compiler/FixEmptyLoggerPass.php
@@ -49,7 +49,7 @@ class FixEmptyLoggerPass implements CompilerPassInterface
                 }
             }
 
-            $def->addMethodCall('pushHandler', array(new Reference('monolog.handler.null_internal')));
+            $def->addMethodCall('pushHandler', [new Reference('monolog.handler.null_internal')]);
         }
     }
 }

--- a/DependencyInjection/Compiler/LoggerChannelPass.php
+++ b/DependencyInjection/Compiler/LoggerChannelPass.php
@@ -26,7 +26,7 @@ use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
  */
 class LoggerChannelPass implements CompilerPassInterface
 {
-    protected $channels = array('app');
+    protected $channels = ['app'];
 
     public function process(ContainerBuilder $container)
     {
@@ -100,7 +100,7 @@ class LoggerChannelPass implements CompilerPassInterface
                     $msg = 'Monolog configuration error: The logging channel "'.$channel.'" assigned to the "'.substr($handler, 16).'" handler does not exist.';
                     throw new \InvalidArgumentException($msg, 0, $e);
                 }
-                $logger->addMethodCall('pushHandler', array(new Reference($handler)));
+                $logger->addMethodCall('pushHandler', [new Reference($handler)]);
             }
         }
     }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -421,10 +421,10 @@ class Configuration implements ConfigurationInterface
                                              */
 
                                             if (is_array($value)) {
-                                                return isset($value['code']) ? $value : array('code' => key($value), 'urls' => current($value));
+                                                return isset($value['code']) ? $value : ['code' => key($value), 'urls' => current($value)];
                                             }
 
-                                            return array('code' => $value, 'urls' => array());
+                                            return ['code' => $value, 'urls' => []];
                                         }, $values);
                                     })
                                 ->end()
@@ -481,7 +481,7 @@ class Configuration implements ConfigurationInterface
                                 ->canBeUnset()
                                 ->beforeNormalization()
                                     ->ifString()
-                                    ->then(function ($v) { return array('id' => $v); })
+                                    ->then(function ($v) { return ['id' => $v]; })
                                 ->end()
                                 ->children()
                                     ->scalarNode('id')->end()
@@ -500,7 +500,7 @@ class Configuration implements ConfigurationInterface
                                 ->canBeUnset()
                                 ->beforeNormalization()
                                     ->ifString()
-                                    ->then(function ($v) { return array('id' => $v); })
+                                    ->then(function ($v) { return ['id' => $v]; })
                                 ->end()
                                 ->children()
                                     ->scalarNode('id')->end()
@@ -528,7 +528,7 @@ class Configuration implements ConfigurationInterface
                                 ->canBeUnset()
                                 ->beforeNormalization()
                                     ->ifString()
-                                    ->then(function ($v) { return array('id' => $v); })
+                                    ->then(function ($v) { return ['id' => $v]; })
                                 ->end()
                                 ->children()
                                     ->scalarNode('id')->end()
@@ -552,7 +552,7 @@ class Configuration implements ConfigurationInterface
                                 ->canBeUnset()
                                 ->beforeNormalization()
                                     ->ifString()
-                                    ->then(function ($v) { return array('id' => $v); })
+                                    ->then(function ($v) { return ['id' => $v]; })
                                 ->end()
                                 ->children()
                                     ->scalarNode('id')->end()
@@ -573,7 +573,7 @@ class Configuration implements ConfigurationInterface
                                 ->canBeUnset()
                                 ->beforeNormalization()
                                     ->ifString()
-                                    ->then(function ($v) { return array('id' => $v); })
+                                    ->then(function ($v) { return ['id' => $v]; })
                                 ->end()
                                 ->children()
                                     ->scalarNode('id')->end()
@@ -600,7 +600,7 @@ class Configuration implements ConfigurationInterface
                                 ->prototype('scalar')->end()
                                 ->beforeNormalization()
                                     ->ifString()
-                                    ->then(function ($v) { return array($v); })
+                                    ->then(function ($v) { return [$v]; })
                                 ->end()
                             ->end()
                             ->scalarNode('subject')->end() // swift_mailer and native_mailer
@@ -614,7 +614,7 @@ class Configuration implements ConfigurationInterface
                                 ->canBeUnset()
                                 ->beforeNormalization()
                                     ->ifString()
-                                    ->then(function ($v) { return array('id' => $v); })
+                                    ->then(function ($v) { return ['id' => $v]; })
                                 ->end()
                                 ->children()
                                     ->scalarNode('id')->isRequired()->end()
@@ -660,8 +660,8 @@ class Configuration implements ConfigurationInterface
                                 ->beforeNormalization()
                                     ->ifArray()
                                     ->then(function ($v) {
-                                        $map = array();
-                                        $verbosities = array('VERBOSITY_QUIET', 'VERBOSITY_NORMAL', 'VERBOSITY_VERBOSE', 'VERBOSITY_VERY_VERBOSE', 'VERBOSITY_DEBUG');
+                                        $map = [];
+                                        $verbosities = ['VERBOSITY_QUIET', 'VERBOSITY_NORMAL', 'VERBOSITY_VERBOSE', 'VERBOSITY_VERY_VERBOSE', 'VERBOSITY_DEBUG'];
                                         // allow numeric indexed array with ascendning verbosity and lowercase names of the constants
                                         foreach ($v as $verbosity => $level) {
                                             if (is_int($verbosity) && isset($verbosities[$verbosity])) {
@@ -683,7 +683,7 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                                 ->validate()
                                     ->always(function ($v) {
-                                        $map = array();
+                                        $map = [];
                                         foreach ($v as $verbosity => $level) {
                                             $verbosityConstant = 'Symfony\Component\Console\Output\OutputInterface::'.$verbosity;
 
@@ -718,11 +718,11 @@ class Configuration implements ConfigurationInterface
                                 ->canBeUnset()
                                 ->beforeNormalization()
                                     ->ifString()
-                                    ->then(function ($v) { return array('elements' => array($v)); })
+                                    ->then(function ($v) { return ['elements' => [$v]]; })
                                 ->end()
                                 ->beforeNormalization()
                                     ->ifTrue(function ($v) { return is_array($v) && is_numeric(key($v)); })
-                                    ->then(function ($v) { return array('elements' => $v); })
+                                    ->then(function ($v) { return ['elements' => $v]; })
                                 ->end()
                                 ->validate()
                                     ->ifTrue(function ($v) { return empty($v); })
@@ -735,7 +735,7 @@ class Configuration implements ConfigurationInterface
                                             $isExclusive = 'exclusive' === $v['type'];
                                         }
 
-                                        $elements = array();
+                                        $elements = [];
                                         foreach ($v['elements'] as $element) {
                                             if (0 === strpos($element, '!')) {
                                                 if (false === $isExclusive) {
@@ -756,13 +756,13 @@ class Configuration implements ConfigurationInterface
                                             return null;
                                         }
 
-                                        return array('type' => $isExclusive ? 'exclusive' : 'inclusive', 'elements' => $elements);
+                                        return ['type' => $isExclusive ? 'exclusive' : 'inclusive', 'elements' => $elements];
                                     })
                                 ->end()
                                 ->children()
                                     ->scalarNode('type')
                                         ->validate()
-                                            ->ifNotInArray(array('inclusive', 'exclusive'))
+                                            ->ifNotInArray(['inclusive', 'exclusive'])
                                             ->thenInvalid('The type of channels has to be inclusive or exclusive')
                                         ->end()
                                     ->end()
@@ -855,11 +855,12 @@ class Configuration implements ConfigurationInterface
                             ->thenInvalid('The token and room have to be specified to use a HipChatHandler')
                         ->end()
                         ->validate()
-                            ->ifTrue(function ($v) { return 'hipchat' === $v['type'] && !in_array($v['message_format'], array('text', 'html')); })
+                            ->ifTrue(function ($v) { return 'hipchat' === $v['type'] && !in_array($v['message_format'], ['text', 'html']
+                                ); })
                             ->thenInvalid('The message_format has to be "text" or "html" in a HipChatHandler')
                         ->end()
                         ->validate()
-                            ->ifTrue(function ($v) { return 'hipchat' === $v['type'] && null !== $v['api_version'] && !in_array($v['api_version'], array('v1', 'v2'), true); })
+                            ->ifTrue(function ($v) { return 'hipchat' === $v['type'] && null !== $v['api_version'] && !in_array($v['api_version'], ['v1', 'v2'], true); })
                             ->thenInvalid('The api_version has to be "v1" or "v2" in a HipChatHandler')
                         ->end()
                         ->validate()
@@ -938,25 +939,27 @@ class Configuration implements ConfigurationInterface
                         ->ifTrue(function ($v) { return isset($v['debug']); })
                         ->thenInvalid('The "debug" name cannot be used as it is reserved for the handler of the profiler')
                     ->end()
-                    ->example(array(
-                        'syslog' => array(
+                    ->example(
+                        [
+                        'syslog' => [
                             'type' => 'stream',
                             'path' => '/var/log/symfony.log',
                             'level' => 'ERROR',
                             'bubble' => 'false',
                             'formatter' => 'my_formatter',
-                            ),
-                        'main' => array(
+                        ],
+                        'main' => [
                             'type' => 'fingers_crossed',
                             'action_level' => 'WARNING',
                             'buffer_size' => 30,
                             'handler' => 'custom',
-                            ),
-                        'custom' => array(
+                        ],
+                        'custom' => [
                             'type' => 'service',
                             'id' => 'my_handler',
-                            )
-                        ))
+                        ]
+                        ]
+                    )
                 ->end()
             ->end()
         ;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -939,8 +939,7 @@ class Configuration implements ConfigurationInterface
                         ->ifTrue(function ($v) { return isset($v['debug']); })
                         ->thenInvalid('The "debug" name cannot be used as it is reserved for the handler of the profiler')
                     ->end()
-                    ->example(
-                        [
+                    ->example([
                         'syslog' => [
                             'type' => 'stream',
                             'path' => '/var/log/symfony.log',
@@ -958,8 +957,7 @@ class Configuration implements ConfigurationInterface
                             'type' => 'service',
                             'id' => 'my_handler',
                         ]
-                        ]
-                    )
+                    ])
                 ->end()
             ->end()
         ;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -855,8 +855,7 @@ class Configuration implements ConfigurationInterface
                             ->thenInvalid('The token and room have to be specified to use a HipChatHandler')
                         ->end()
                         ->validate()
-                            ->ifTrue(function ($v) { return 'hipchat' === $v['type'] && !in_array($v['message_format'], ['text', 'html']
-                                ); })
+                            ->ifTrue(function ($v) { return 'hipchat' === $v['type'] && !in_array($v['message_format'], ['text', 'html']); })
                             ->thenInvalid('The message_format has to be "text" or "html" in a HipChatHandler')
                         ->end()
                         ->validate()

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -89,8 +89,7 @@ class MonologExtension extends Extension
             $container->setParameter('monolog.handlers_to_channels', $handlersToChannels);
 
             if (PHP_VERSION_ID < 70000) {
-                $this->addClassesToCompile(
-                    [
+                $this->addClassesToCompile([
                     'Monolog\\Formatter\\FormatterInterface',
                     'Monolog\\Formatter\\LineFormatter',
                     'Monolog\\Handler\\HandlerInterface',
@@ -104,8 +103,7 @@ class MonologExtension extends Extension
                     'Symfony\\Bridge\\Monolog\\Logger',
                     'Monolog\\Handler\\FingersCrossed\\ActivationStrategyInterface',
                     'Monolog\\Handler\\FingersCrossed\\ErrorLevelActivationStrategy',
-                    ]
-                );
+                ]);
             }
         }
 
@@ -178,36 +176,30 @@ class MonologExtension extends Extension
 
         switch ($handler['type']) {
         case 'stream':
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 $handler['path'],
                 $handler['level'],
                 $handler['bubble'],
                 $handler['file_permission'],
                 $handler['use_locking'],
-                ]
-            );
+            ]);
             break;
 
         case 'console':
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 null,
                 $handler['bubble'],
                 isset($handler['verbosity_levels']) ? $handler['verbosity_levels'] : [],
                 $handler['console_formater_options']
-                ]
-            );
+            ]);
             $definition->addTag('kernel.event_subscriber');
             break;
 
         case 'firephp':
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 $handler['level'],
                 $handler['bubble'],
-                ]
-            );
+            ]);
             $definition->addTag('kernel.event_listener', ['event' => 'kernel.response', 'method' => 'onKernelResponse']);
             break;
 
@@ -239,13 +231,11 @@ class MonologExtension extends Extension
                 throw new \RuntimeException('The gelf handler requires the graylog2/gelf-php package to be installed');
             }
 
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 $publisher,
                 $handler['level'],
                 $handler['bubble'],
-                ]
-            );
+            ]);
             break;
 
         case 'mongo':
@@ -268,15 +258,13 @@ class MonologExtension extends Extension
                 $client->setPublic(false);
             }
 
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 $client,
                 $handler['mongo']['database'],
                 $handler['mongo']['collection'],
                 $handler['level'],
                 $handler['bubble'],
-                ]
-            );
+            ]);
             break;
 
         case 'elasticsearch':
@@ -302,18 +290,15 @@ class MonologExtension extends Extension
                     );
                 }
 
-                $elasticaClient->setArguments(
-                    [
+                $elasticaClient->setArguments([
                     $elasticaClientArguments
-                    ]
-                );
+                ]);
 
                 $elasticaClient->setPublic(false);
             }
 
             // elastica handler definition
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 $elasticaClient,
                 [
                     'index' => $handler['index'],
@@ -322,8 +307,7 @@ class MonologExtension extends Extension
                 ],
                 $handler['level'],
                 $handler['bubble'],
-                ]
-            );
+            ]);
             break;
         case 'redis':
         case 'predis':
@@ -347,46 +331,38 @@ class MonologExtension extends Extension
                 }
 
                 $client = new Definition(\Predis\Client::class);
-                $client->setArguments(
-                    [
+                $client->setArguments([
                     $handler['redis']['host'],
-                    ]
-                );
+                ]);
                 $client->setPublic(false);
 
                 $clientId = uniqid('monolog.predis.client.', true);
                 $container->setDefinition($clientId, $client);
             }
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 new Reference($clientId),
                 $handler['redis']['key_name'],
                 $handler['level'],
                 $handler['bubble'],
-                ]
-            );
+            ]);
             break;
 
         case 'chromephp':
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 $handler['level'],
                 $handler['bubble'],
-                ]
-            );
+            ]);
             $definition->addTag('kernel.event_listener', ['event' => 'kernel.response', 'method' => 'onKernelResponse']);
             break;
 
         case 'rotating_file':
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 $handler['path'],
                 $handler['max_files'],
                 $handler['level'],
                 $handler['bubble'],
                 $handler['file_permission'],
-                ]
-            );
+            ]);
             $definition->addMethodCall('setFilenameFormat', [
                 $handler['filename_format'],
                 $handler['date_format'],
@@ -432,16 +408,14 @@ class MonologExtension extends Extension
                 $activation = $handler['action_level'];
             }
 
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 new Reference($nestedHandlerId),
                 $activation,
                 $handler['buffer_size'],
                 $handler['bubble'],
                 $handler['stop_buffering'],
                 $handler['passthru_level'],
-                ]
-            );
+            ]);
             break;
 
         case 'filter':
@@ -455,29 +429,25 @@ class MonologExtension extends Extension
             $this->markNestedHandler($nestedHandlerId);
             $minLevelOrList = !empty($handler['accepted_levels']) ? $handler['accepted_levels'] : $handler['min_level'];
 
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 new Reference($nestedHandlerId),
                 $minLevelOrList,
                 $handler['max_level'],
                 $handler['bubble'],
-                ]
-            );
+            ]);
             break;
 
         case 'buffer':
             $nestedHandlerId = $this->getHandlerId($handler['handler']);
             $this->markNestedHandler($nestedHandlerId);
 
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 new Reference($nestedHandlerId),
                 $handler['buffer_size'],
                 $handler['level'],
                 $handler['bubble'],
                 $handler['flush_on_overflow'],
-                ]
-            );
+            ]);
             break;
 
         case 'deduplication':
@@ -485,15 +455,13 @@ class MonologExtension extends Extension
             $this->markNestedHandler($nestedHandlerId);
             $defaultStore = '%kernel.cache_dir%/monolog_dedup_'.sha1($handlerId);
 
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 new Reference($nestedHandlerId),
                 isset($handler['store']) ? $handler['store'] : $defaultStore,
                 $handler['deduplication_level'],
                 $handler['time'],
                 $handler['bubble'],
-                ]
-            );
+            ]);
             break;
 
         case 'group':
@@ -505,36 +473,30 @@ class MonologExtension extends Extension
                 $references[] = new Reference($nestedHandlerId);
             }
 
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 $references,
                 $handler['bubble'],
-                ]
-            );
+            ]);
             break;
 
         case 'syslog':
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 $handler['ident'],
                 $handler['facility'],
                 $handler['level'],
                 $handler['bubble'],
                 $handler['logopts'],
-                ]
-            );
+            ]);
             break;
 
         case 'syslogudp':
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 $handler['host'],
                 $handler['port'],
                 $handler['facility'],
                 $handler['level'],
                 $handler['bubble'],
-                ]
-            );
+            ]);
             if ($handler['ident']) {
                 $definition->addArgument($handler['ident']);
             }
@@ -551,29 +513,25 @@ class MonologExtension extends Extension
                 $messageFactory = new Definition('Symfony\Bundle\MonologBundle\SwiftMailer\MessageFactory');
                 $messageFactory->setLazy(true);
                 $messageFactory->setPublic(false);
-                $messageFactory->setArguments(
-                    [
+                $messageFactory->setArguments([
                     new Reference($handler['mailer']),
                     $handler['from_email'],
                     $handler['to_email'],
                     $handler['subject'],
                     $handler['content_type']
-                    ]
-                );
+                ]);
 
                 $messageFactoryId = sprintf('%s.mail_message_factory', $handlerId);
                 $container->setDefinition($messageFactoryId, $messageFactory);
                 // set the prototype as a callable
                 $prototype = [new Reference($messageFactoryId), 'createMessage'];
             }
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 new Reference($handler['mailer']),
                 $prototype,
                 $handler['level'],
                 $handler['bubble'],
-                ]
-            );
+            ]);
 
             $this->swiftMailerHandlers[] = $handlerId;
             $definition->addTag('kernel.event_listener', ['event' => 'kernel.terminate', 'method' => 'onKernelTerminate']
@@ -582,28 +540,24 @@ class MonologExtension extends Extension
             break;
 
         case 'native_mailer':
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 $handler['to_email'],
                 $handler['subject'],
                 $handler['from_email'],
                 $handler['level'],
                 $handler['bubble'],
-                ]
-            );
+            ]);
             if (!empty($handler['headers'])) {
                 $definition->addMethodCall('addHeader', [$handler['headers']]);
             }
             break;
 
         case 'socket':
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 $handler['connection_string'],
                 $handler['level'],
                 $handler['bubble'],
-                ]
-            );
+            ]);
             if (isset($handler['timeout'])) {
                 $definition->addMethodCall('setTimeout', [$handler['timeout']]);
             }
@@ -616,15 +570,13 @@ class MonologExtension extends Extension
             break;
 
         case 'pushover':
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 $handler['token'],
                 $handler['user'],
                 $handler['title'],
                 $handler['level'],
                 $handler['bubble'],
-                ]
-            );
+            ]);
             if (isset($handler['timeout'])) {
                 $definition->addMethodCall('setTimeout', [$handler['timeout']]);
             }
@@ -634,8 +586,7 @@ class MonologExtension extends Extension
             break;
 
         case 'hipchat':
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 $handler['token'],
                 $handler['room'],
                 $handler['nickname'],
@@ -646,8 +597,7 @@ class MonologExtension extends Extension
                 $handler['message_format'],
                 !empty($handler['host']) ? $handler['host'] : 'api.hipchat.com',
                 !empty($handler['api_version']) ? $handler['api_version'] : 'v1',
-                ]
-            );
+            ]);
             if (isset($handler['timeout'])) {
                 $definition->addMethodCall('setTimeout', [$handler['timeout']]);
             }
@@ -657,8 +607,7 @@ class MonologExtension extends Extension
             break;
 
         case 'slack':
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 $handler['token'],
                 $handler['channel'],
                 $handler['bot_name'],
@@ -668,8 +617,7 @@ class MonologExtension extends Extension
                 $handler['bubble'],
                 $handler['use_short_attachment'],
                 $handler['include_extra'],
-                ]
-            );
+            ]);
             if (isset($handler['timeout'])) {
                 $definition->addMethodCall('setTimeout', [$handler['timeout']]);
             }
@@ -679,8 +627,7 @@ class MonologExtension extends Extension
             break;
 
         case 'slackwebhook':
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 $handler['webhook_url'],
                 $handler['channel'],
                 $handler['bot_name'],
@@ -690,51 +637,42 @@ class MonologExtension extends Extension
                 $handler['include_extra'],
                 $handler['level'],
                 $handler['bubble'],
-                ]
-            );
+            ]);
             break;
 
         case 'slackbot':
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 $handler['team'],
                 $handler['token'],
                 urlencode($handler['channel']),
                 $handler['level'],
                 $handler['bubble'],
-                ]
-            );
+            ]);
             break;
 
         case 'cube':
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 $handler['url'],
                 $handler['level'],
                 $handler['bubble'],
-                ]
-            );
+            ]);
             break;
 
         case 'amqp':
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 new Reference($handler['exchange']),
                 $handler['exchange_name'],
                 $handler['level'],
                 $handler['bubble'],
-                ]
-            );
+            ]);
             break;
 
         case 'error_log':
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 $handler['message_type'],
                 $handler['level'],
                 $handler['bubble'],
-                ]
-            );
+            ]);
             break;
 
         case 'sentry':
@@ -775,13 +713,11 @@ class MonologExtension extends Extension
             // can't set the hub to the current hub, getting into a recursion otherwise...
             //$hub->addMethodCall('setCurrent', array($hub));
 
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 $hub,
                 $handler['level'],
                 $handler['bubble'],
-                ]
-            );
+            ]);
             break;
 
         case 'raven':
@@ -800,40 +736,34 @@ class MonologExtension extends Extension
                 $clientId = 'monolog.raven.client.'.sha1($handler['dsn']);
                 $container->setDefinition($clientId, $client);
             }
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 new Reference($clientId),
                 $handler['level'],
                 $handler['bubble'],
-                ]
-            );
+            ]);
             if (!empty($handler['release'])) {
                 $definition->addMethodCall('setRelease', [$handler['release']]);
             }
             break;
 
         case 'loggly':
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 $handler['token'],
                 $handler['level'],
                 $handler['bubble'],
-                ]
-            );
+            ]);
             if (!empty($handler['tags'])) {
                 $definition->addMethodCall('setTag', [implode(',', $handler['tags'])]);
             }
             break;
 
         case 'logentries':
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 $handler['token'],
                 $handler['use_ssl'],
                 $handler['level'],
                 $handler['bubble'],
-                ]
-            );
+            ]);
             if (isset($handler['timeout'])) {
                 $definition->addMethodCall('setTimeout', [$handler['timeout']]);
             }
@@ -843,25 +773,21 @@ class MonologExtension extends Extension
             break;
 
         case 'insightops':
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 $handler['token'],
                 $handler['region'] ? $handler['region'] : 'us',
                 $handler['use_ssl'],
                 $handler['level'],
                 $handler['bubble'],
-                ]
-            );
+            ]);
             break;
 
         case 'flowdock':
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 $handler['token'],
                 $handler['level'],
                 $handler['bubble'],
-                ]
-            );
+            ]);
 
             if (empty($handler['formatter'])) {
                 $formatter = new Definition("Monolog\Formatter\FlowdockFormatter", [
@@ -892,35 +818,29 @@ class MonologExtension extends Extension
                 $container->setDefinition($rollbarId, $rollbar);
             }
 
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 new Reference($rollbarId),
                 $handler['level'],
                 $handler['bubble'],
-                ]
-            );
+            ]);
             break;
         case 'newrelic':
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 $handler['level'],
                 $handler['bubble'],
                 $handler['app_name'],
-                ]
-            );
+            ]);
             break;
         case 'server_log':
             if (!class_exists('Symfony\Bridge\Monolog\Handler\ServerLogHandler')) {
                 throw new \RuntimeException('The ServerLogHandler is not available. Please update "symfony/monolog-bridge" to 3.3.');
             }
 
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 $handler['host'],
                 $handler['level'],
                 $handler['bubble'],
-                ]
-            );
+            ]);
             break;
 
         // Handlers using the constructor of AbstractHandler without adding their own arguments
@@ -928,12 +848,10 @@ class MonologExtension extends Extension
         case 'test':
         case 'null':
         case 'debug':
-            $definition->setArguments(
-                [
+            $definition->setArguments([
                 $handler['level'],
                 $handler['bubble'],
-                ]
-            );
+            ]);
             break;
 
         default:

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -211,8 +211,7 @@ class MonologExtension extends Extension
                     $handler['publisher']['hostname'],
                     $handler['publisher']['port'],
                     $handler['publisher']['chunk_size'],
-                ]
-                );
+                ]);
                 $transport->setPublic(false);
 
                 $publisher = new Definition('Gelf\Publisher', []);
@@ -223,8 +222,7 @@ class MonologExtension extends Extension
                     $handler['publisher']['hostname'],
                     $handler['publisher']['port'],
                     $handler['publisher']['chunk_size'],
-                ]
-                );
+                ]);
 
                 $publisher->setPublic(false);
             } else {
@@ -252,8 +250,7 @@ class MonologExtension extends Extension
 
                 $client = new Definition('MongoClient', [
                     $server,
-                ]
-                );
+                ]);
 
                 $client->setPublic(false);
             }
@@ -366,8 +363,7 @@ class MonologExtension extends Extension
             $definition->addMethodCall('setFilenameFormat', [
                 $handler['filename_format'],
                 $handler['date_format'],
-            ]
-            );
+            ]);
             break;
 
         case 'fingers_crossed':
@@ -388,8 +384,7 @@ class MonologExtension extends Extension
                     new Reference('request_stack'),
                     $handler['excluded_404s'],
                     $handler['action_level']
-                ]
-                );
+                ]);
                 $container->setDefinition($handlerId.'.not_found_strategy', $activationDef);
                 $activation = new Reference($handlerId.'.not_found_strategy');
             } elseif (!empty($handler['excluded_http_codes'])) {
@@ -400,8 +395,7 @@ class MonologExtension extends Extension
                     new Reference('request_stack'),
                     $handler['excluded_http_codes'],
                     $handler['action_level']
-                ]
-                );
+                ]);
                 $container->setDefinition($handlerId.'.http_code_strategy', $activationDef);
                 $activation = new Reference($handlerId.'.http_code_strategy');
             } else {
@@ -534,8 +528,7 @@ class MonologExtension extends Extension
             ]);
 
             $this->swiftMailerHandlers[] = $handlerId;
-            $definition->addTag('kernel.event_listener', ['event' => 'kernel.terminate', 'method' => 'onKernelTerminate']
-            );
+            $definition->addTag('kernel.event_listener', ['event' => 'kernel.terminate', 'method' => 'onKernelTerminate']);
             $definition->addTag('kernel.event_listener', ['event' => 'console.terminate', 'method' => 'onCliTerminate']);
             break;
 
@@ -730,8 +723,7 @@ class MonologExtension extends Extension
                         'auto_log_stacks' => $handler['auto_log_stacks'],
                         'environment' => $handler['environment']
                     ]
-                ]
-                );
+                ]);
                 $client->setPublic(false);
                 $clientId = 'monolog.raven.client.'.sha1($handler['dsn']);
                 $container->setDefinition($clientId, $client);
@@ -793,8 +785,7 @@ class MonologExtension extends Extension
                 $formatter = new Definition("Monolog\Formatter\FlowdockFormatter", [
                     $handler['source'],
                     $handler['from_email'],
-                ]
-                );
+                ]);
                 $formatterId = 'monolog.flowdock.formatter.'.sha1($handler['source'].'|'.$handler['from_email']);
                 $formatter->setPublic(false);
                 $container->setDefinition($formatterId, $formatter);
@@ -811,8 +802,7 @@ class MonologExtension extends Extension
                 $config['access_token'] = $handler['token'];
                 $rollbar = new Definition('RollbarNotifier', [
                     $config,
-                ]
-                );
+                ]);
                 $rollbarId = 'monolog.rollbar.notifier.'.sha1(json_encode($config));
                 $rollbar->setPublic(false);
                 $container->setDefinition($rollbarId, $rollbar);

--- a/Tests/DependencyInjection/Compiler/AddProcessorsPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddProcessorsPassTest.php
@@ -28,12 +28,12 @@ class AddProcessorsPassTest extends TestCase
         $service = $container->getDefinition('monolog.handler.test');
         $calls = $service->getMethodCalls();
         $this->assertCount(1, $calls);
-        $this->assertEquals(array('pushProcessor', array(new Reference('test'))), $calls[0]);
+        $this->assertEquals(['pushProcessor', [new Reference('test')]], $calls[0]);
 
         $service = $container->getDefinition('handler_test');
         $calls = $service->getMethodCalls();
         $this->assertCount(1, $calls);
-        $this->assertEquals(array('pushProcessor', array(new Reference('test2'))), $calls[0]);
+        $this->assertEquals(['pushProcessor', [new Reference('test2')]], $calls[0]);
     }
 
     protected function getContainer()
@@ -43,22 +43,22 @@ class AddProcessorsPassTest extends TestCase
         $loader->load('monolog.xml');
 
         $definition = $container->getDefinition('monolog.logger_prototype');
-        $container->setDefinition('monolog.handler.test', new Definition('%monolog.handler.null.class%', array(100, false)));
-        $container->setDefinition('handler_test', new Definition('%monolog.handler.null.class%', array(100, false)));
+        $container->setDefinition('monolog.handler.test', new Definition('%monolog.handler.null.class%', [100, false]));
+        $container->setDefinition('handler_test', new Definition('%monolog.handler.null.class%', [100, false]));
         $container->setAlias('monolog.handler.test2', 'handler_test');
-        $definition->addMethodCall('pushHandler', array(new Reference('monolog.handler.test')));
-        $definition->addMethodCall('pushHandler', array(new Reference('monolog.handler.test2')));
+        $definition->addMethodCall('pushHandler', [new Reference('monolog.handler.test')]);
+        $definition->addMethodCall('pushHandler', [new Reference('monolog.handler.test2')]);
 
-        $service = new Definition('TestClass', array('false', new Reference('logger')));
-        $service->addTag('monolog.processor', array('handler' => 'test'));
+        $service = new Definition('TestClass', ['false', new Reference('logger')]);
+        $service->addTag('monolog.processor', ['handler' => 'test']);
         $container->setDefinition('test', $service);
 
-        $service = new Definition('TestClass', array('false', new Reference('logger')));
-        $service->addTag('monolog.processor', array('handler' => 'test2'));
+        $service = new Definition('TestClass', ['false', new Reference('logger')]);
+        $service->addTag('monolog.processor', ['handler' => 'test2']);
         $container->setDefinition('test2', $service);
 
-        $container->getCompilerPassConfig()->setOptimizationPasses(array());
-        $container->getCompilerPassConfig()->setRemovingPasses(array());
+        $container->getCompilerPassConfig()->setOptimizationPasses([]);
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
         $container->addCompilerPass(new AddProcessorsPass());
         $container->compile();
 

--- a/Tests/DependencyInjection/Compiler/AddSwiftMailerTransportPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddSwiftMailerTransportPassTest.php
@@ -35,11 +35,11 @@ class AddSwiftMailerTransportPassTest extends TestCase
             ->with(0)
             ->will($this->returnValue(new Reference('swiftmailer')));
         $this->container = $this->getMockBuilder('\Symfony\Component\DependencyInjection\ContainerBuilder')
-            ->setMethods(array('getParameter', 'getDefinition', 'hasDefinition', 'addMethodCall'))->getMock();
+            ->setMethods(['getParameter', 'getDefinition', 'hasDefinition', 'addMethodCall'])->getMock();
         $this->container->expects($this->any())
             ->method('getParameter')
             ->with('monolog.swift_mailer.handlers')
-            ->will($this->returnValue(array('foo')));
+            ->will($this->returnValue(['foo']));
         $this->container->expects($this->any())
             ->method('getDefinition')
             ->with('foo')
@@ -58,7 +58,7 @@ class AddSwiftMailerTransportPassTest extends TestCase
             ->method('addMethodCall')
             ->with(
                 'setTransport',
-                $this->equalTo(array(new Reference('swiftmailer.transport.real')))
+                $this->equalTo([new Reference('swiftmailer.transport.real')])
             );
 
         $this->compilerPass->process($this->container);
@@ -70,17 +70,17 @@ class AddSwiftMailerTransportPassTest extends TestCase
             ->expects($this->any())
             ->method('hasDefinition')
             ->will($this->returnValueMap(
-                array(
-                    array('swiftmailer.transport.real', false),
-                    array('swiftmailer.transport', true),
-                )
+                [
+                    ['swiftmailer.transport.real', false],
+                    ['swiftmailer.transport', true],
+                ]
             ));
         $this->definition
             ->expects($this->once())
             ->method('addMethodCall')
             ->with(
                 'setTransport',
-                $this->equalTo(array(new Reference('swiftmailer.transport')))
+                $this->equalTo([new Reference('swiftmailer.transport')])
             );
 
         $this->compilerPass->process($this->container);

--- a/Tests/DependencyInjection/Compiler/FixEmptyLoggerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/FixEmptyLoggerPassTest.php
@@ -20,7 +20,7 @@ class FixEmptyLoggerPassTest extends TestCase
     public function testProcess()
     {
         $loggerChannelPass = $this->getMockBuilder('Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\LoggerChannelPass')->getMock();
-        $loggerChannelPass->expects($this->any())->method('getChannels')->will($this->returnValue(array('foo', 'bar')));
+        $loggerChannelPass->expects($this->any())->method('getChannels')->will($this->returnValue(['foo', 'bar']));
 
         $container = new ContainerBuilder();
         $container->register('monolog.logger.foo', 'Monolog\Logger');

--- a/Tests/DependencyInjection/Compiler/LoggerChannelPassTest.php
+++ b/Tests/DependencyInjection/Compiler/LoggerChannelPassTest.php
@@ -31,11 +31,11 @@ class LoggerChannelPassTest extends TestCase
         $this->assertEquals('monolog.logger.test', (string) $service->getArgument(1), '->process replaces the logger by the new one');
 
         // pushHandlers for service "test"
-        $expected = array(
-            'test' => array('monolog.handler.a', 'monolog.handler.b', 'monolog.handler.c'),
-            'foo'  => array('monolog.handler.b'),
-            'bar'  => array('monolog.handler.b', 'monolog.handler.c'),
-        );
+        $expected = [
+            'test' => ['monolog.handler.a', 'monolog.handler.b', 'monolog.handler.c'],
+            'foo'  => ['monolog.handler.b'],
+            'bar'  => ['monolog.handler.b', 'monolog.handler.c'],
+        ];
 
         foreach ($expected as $serviceName => $handlers) {
             $service = $container->getDefinition($serviceName);
@@ -75,7 +75,7 @@ class LoggerChannelPassTest extends TestCase
         $dummyService = $container->register('dummy_service', 'Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Compiler\DummyService')
             ->setAutowired(true)
             ->setPublic(true)
-            ->addTag('monolog.logger', array('channel' => 'test'));
+            ->addTag('monolog.logger', ['channel' => 'test']);
 
         $container->compile();
 
@@ -97,7 +97,7 @@ class LoggerChannelPassTest extends TestCase
             ->setAutowired(true)
             ->setAutoconfigured(true)
             ->setPublic(true)
-            ->addTag('monolog.logger', array('channel' => 'test'));
+            ->addTag('monolog.logger', ['channel' => 'test']);
 
         $container->compile();
 
@@ -115,7 +115,7 @@ class LoggerChannelPassTest extends TestCase
         $dummyService = $container->register('dummy_service', 'Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Compiler\DummyService')
             ->setAutowired(true)
             ->addArgument(new Reference('monolog.logger'))
-            ->addTag('monolog.logger', array('channel' => 'test'));
+            ->addTag('monolog.logger', ['channel' => 'test']);
 
         $container->compile();
 
@@ -127,18 +127,18 @@ class LoggerChannelPassTest extends TestCase
         $container = $this->getFunctionalContainer();
 
         $dummyService = $container->register('dummy_service', 'stdClass')
-            ->addTag('monolog.logger', array('channel' => 'test'));
+            ->addTag('monolog.logger', ['channel' => 'test']);
 
         $container->compile();
 
-        $this->assertEquals(array(), $dummyService->getArguments());
+        $this->assertEquals([], $dummyService->getArguments());
     }
 
     public function testChannelsConfigurationOptionSupportsAppChannel()
     {
         $container = $this->getFunctionalContainer();
 
-        $container->setParameter('monolog.additional_channels', array('app'));
+        $container->setParameter('monolog.additional_channels', ['app']);
         $container->compile();
 
         // the test ensures that the validation does not fail (i.e. it does not throw any exceptions)
@@ -151,36 +151,37 @@ class LoggerChannelPassTest extends TestCase
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../../../Resources/config'));
         $loader->load('monolog.xml');
         $definition = $container->getDefinition('monolog.logger_prototype');
-        $container->set('monolog.handler.test', new Definition('%monolog.handler.null.class%', array(100, false)));
-        $definition->addMethodCall('pushHandler', array(new Reference('monolog.handler.test')));
+        $container->set('monolog.handler.test', new Definition('%monolog.handler.null.class%', [100, false]));
+        $definition->addMethodCall('pushHandler', [new Reference('monolog.handler.test')]);
 
         // Handlers
-        $container->set('monolog.handler.a', new Definition('%monolog.handler.null.class%', array(100, false)));
-        $container->set('monolog.handler.b', new Definition('%monolog.handler.null.class%', array(100, false)));
-        $container->set('monolog.handler.c', new Definition('%monolog.handler.null.class%', array(100, false)));
+        $container->set('monolog.handler.a', new Definition('%monolog.handler.null.class%', [100, false]));
+        $container->set('monolog.handler.b', new Definition('%monolog.handler.null.class%', [100, false]));
+        $container->set('monolog.handler.c', new Definition('%monolog.handler.null.class%', [100, false]));
 
         // Channels
-        foreach (array('test', 'foo', 'bar') as $name) {
-            $service = new Definition('TestClass', array('false', new Reference('logger')));
-            $service->addTag('monolog.logger', array('channel' => $name));
+        foreach (['test', 'foo', 'bar'] as $name) {
+            $service = new Definition('TestClass', ['false', new Reference('logger')]);
+            $service->addTag('monolog.logger', ['channel' => $name]);
             $container->setDefinition($name, $service);
         }
 
-        $container->setParameter('monolog.additional_channels', array('manualchan'));
-        $container->setParameter('monolog.handlers_to_channels', array(
-            'monolog.handler.a' => array(
+        $container->setParameter('monolog.additional_channels', ['manualchan']);
+        $container->setParameter('monolog.handlers_to_channels', [
+            'monolog.handler.a' => [
                 'type' => 'inclusive',
-                'elements' => array('test')
-            ),
+                'elements' => ['test']
+            ],
             'monolog.handler.b' => null,
-            'monolog.handler.c' => array(
+            'monolog.handler.c' => [
                 'type' => 'exclusive',
-                'elements' => array('foo')
-            )
-        ));
+                'elements' => ['foo']
+            ]
+        ]
+        );
 
-        $container->getCompilerPassConfig()->setOptimizationPasses(array());
-        $container->getCompilerPassConfig()->setRemovingPasses(array());
+        $container->getCompilerPassConfig()->setOptimizationPasses([]);
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
         $container->addCompilerPass(new LoggerChannelPass());
         $container->compile();
 
@@ -193,20 +194,20 @@ class LoggerChannelPassTest extends TestCase
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../../../Resources/config'));
         $loader->load('monolog.xml');
         $definition = $container->getDefinition('monolog.logger_prototype');
-        $container->set('monolog.handler.test', new Definition('%monolog.handler.null.class%', array(100, false)));
-        $definition->addMethodCall('pushHandler', array(new Reference('monolog.handler.test')));
+        $container->set('monolog.handler.test', new Definition('%monolog.handler.null.class%', [100, false]));
+        $definition->addMethodCall('pushHandler', [new Reference('monolog.handler.test')]);
 
         // Channels
         $service = new Definition('TestClass');
-        $service->addTag('monolog.logger', array('channel' => 'test'));
-        $service->addMethodCall('setLogger', array(new Reference('logger')));
+        $service->addTag('monolog.logger', ['channel' => 'test']);
+        $service->addMethodCall('setLogger', [new Reference('logger')]);
         $container->setDefinition('foo', $service);
 
-        $container->setParameter('monolog.additional_channels', array('manualchan'));
-        $container->setParameter('monolog.handlers_to_channels', array());
+        $container->setParameter('monolog.additional_channels', ['manualchan']);
+        $container->setParameter('monolog.handlers_to_channels', []);
 
-        $container->getCompilerPassConfig()->setOptimizationPasses(array());
-        $container->getCompilerPassConfig()->setRemovingPasses(array());
+        $container->getCompilerPassConfig()->setOptimizationPasses([]);
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
         $container->addCompilerPass(new LoggerChannelPass());
         $container->compile();
 
@@ -219,8 +220,8 @@ class LoggerChannelPassTest extends TestCase
     private function getFunctionalContainer()
     {
         $container = new ContainerBuilder();
-        $container->setParameter('monolog.additional_channels', array());
-        $container->setParameter('monolog.handlers_to_channels', array());
+        $container->setParameter('monolog.additional_channels', []);
+        $container->setParameter('monolog.handlers_to_channels', []);
         $container->setParameter('monolog.use_microseconds', true);
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../../../Resources/config'));
@@ -229,7 +230,7 @@ class LoggerChannelPassTest extends TestCase
         $container->addCompilerPass(new LoggerChannelPass());
 
         // disable removing passes to be able to inspect the container before all the inlining optimizations
-        $container->getCompilerPassConfig()->setRemovingPasses(array());
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
 
         return $container;
     }

--- a/Tests/DependencyInjection/Compiler/LoggerChannelPassTest.php
+++ b/Tests/DependencyInjection/Compiler/LoggerChannelPassTest.php
@@ -177,8 +177,7 @@ class LoggerChannelPassTest extends TestCase
                 'type' => 'exclusive',
                 'elements' => ['foo']
             ]
-        ]
-        );
+        ]);
 
         $container->getCompilerPassConfig()->setOptimizationPasses([]);
         $container->getCompilerPassConfig()->setRemovingPasses([]);

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -264,8 +264,7 @@ class ConfigurationTest extends TestCase
         $config = $this->process($configs);
 
         $this->assertSame('console', $config['handlers']['console']['type']);
-        $this->assertSame(
-            [
+        $this->assertSame([
             OutputInterface::VERBOSITY_NORMAL => Logger::NOTICE,
             OutputInterface::VERBOSITY_VERBOSE => Logger::INFO,
             OutputInterface::VERBOSITY_VERY_VERBOSE => 150,

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -25,11 +25,11 @@ class ConfigurationTest extends TestCase
      */
     public function testProcessSimpleCase()
     {
-        $configs = array(
-            array(
-                'handlers' => array('foobar' => array('type' => 'stream', 'path' => '/foo/bar'))
-            )
-        );
+        $configs = [
+            [
+                'handlers' => ['foobar' => ['type' => 'stream', 'path' => '/foo/bar']]
+            ]
+        ];
 
         $config = $this->process($configs);
 
@@ -42,10 +42,10 @@ class ConfigurationTest extends TestCase
 
     public function provideProcessStringChannels()
     {
-        return array(
-            array('foo', 'foo', true),
-            array('!foo', 'foo', false)
-        );
+        return [
+            ['foo', 'foo', true],
+            ['!foo', 'foo', false]
+        ];
     }
 
     /**
@@ -53,17 +53,17 @@ class ConfigurationTest extends TestCase
      */
     public function testProcessStringChannels($string, $expectedString, $isInclusive)
     {
-        $configs = array(
-            array(
-                'handlers' => array(
-                    'foobar' => array(
+        $configs = [
+            [
+                'handlers' => [
+                    'foobar' => [
                         'type' => 'stream',
                         'path' => '/foo/bar',
                         'channels' => $string
-                    )
-                )
-            )
-        );
+                    ]
+                ]
+            ]
+        ];
 
         $config = $this->process($configs);
 
@@ -74,16 +74,16 @@ class ConfigurationTest extends TestCase
 
     public function provideGelfPublisher()
     {
-        return array(
-            array(
+        return [
+            [
                 'gelf.publisher'
-            ),
-            array(
-                array(
+            ],
+            [
+                [
                     'id' => 'gelf.publisher'
-                )
-            )
-        );
+                ]
+            ]
+        ];
     }
 
     /**
@@ -91,16 +91,16 @@ class ConfigurationTest extends TestCase
      */
     public function testGelfPublisherService($publisher)
     {
-        $configs = array(
-            array(
-                'handlers' => array(
-                    'gelf' => array(
+        $configs = [
+            [
+                'handlers' => [
+                    'gelf' => [
                         'type' => 'gelf',
                         'publisher' => $publisher,
-                    ),
-                )
-            )
-        );
+                    ],
+                ]
+            ]
+        ];
 
         $config = $this->process($configs);
 
@@ -111,22 +111,22 @@ class ConfigurationTest extends TestCase
 
     public function testArrays()
     {
-        $configs = array(
-            array(
-                'handlers' => array(
-                    'foo' => array(
+        $configs = [
+            [
+                'handlers' => [
+                    'foo' => [
                         'type' => 'stream',
                         'path' => '/foo',
-                        'channels' => array('A', 'B')
-                    ),
-                    'bar' => array(
+                        'channels' => ['A', 'B']
+                    ],
+                    'bar' => [
                         'type' => 'stream',
                         'path' => '/foo',
-                        'channels' => array('!C', '!D')
-                    ),
-                )
-            )
-        );
+                        'channels' => ['!C', '!D']
+                    ],
+                ]
+            ]
+        ];
 
         $config = $this->process($configs);
 
@@ -148,17 +148,17 @@ class ConfigurationTest extends TestCase
      */
     public function testInvalidArrays()
     {
-        $configs = array(
-            array(
-                'handlers' => array(
-                    'foo' => array(
+        $configs = [
+            [
+                'handlers' => [
+                    'foo' => [
                         'type' => 'stream',
                         'path' => '/foo',
-                        'channels' => array('A', '!B')
-                    )
-                )
-            )
-        );
+                        'channels' => ['A', '!B']
+                    ]
+                ]
+            ]
+        ];
 
         $config = $this->process($configs);
     }
@@ -168,47 +168,47 @@ class ConfigurationTest extends TestCase
      */
     public function testMergingInvalidChannels()
     {
-        $configs = array(
-            array(
-                'handlers' => array(
-                    'foo' => array(
+        $configs = [
+            [
+                'handlers' => [
+                    'foo' => [
                         'type' => 'stream',
                         'path' => '/foo',
                         'channels' => 'A',
-                    )
-                )
-            ),
-            array(
-                'handlers' => array(
-                    'foo' => array(
+                    ]
+                ]
+            ],
+            [
+                'handlers' => [
+                    'foo' => [
                         'channels' => '!B',
-                    )
-                )
-            )
-        );
+                    ]
+                ]
+            ]
+        ];
 
         $config = $this->process($configs);
     }
 
     public function testWithSwiftMailerHandler()
     {
-        $configs = array(
-            array(
-                'handlers' => array(
-                    'swift' => array(
+        $configs = [
+            [
+                'handlers' => [
+                    'swift' => [
                         'type' => 'swift_mailer',
                         'from_email' => 'foo@bar.com',
                         'to_email' => 'foo@bar.com',
                         'subject' => 'Subject',
                         'mailer'  => 'mailer',
-                        'email_prototype' => array(
+                        'email_prototype' => [
                             'id' => 'monolog.prototype',
                             'method' => 'getPrototype'
-                        )
-                    )
-                )
-            )
-        );
+                        ]
+                    ]
+                ]
+            ]
+        ];
 
         $config = $this->process($configs);
 
@@ -221,21 +221,21 @@ class ConfigurationTest extends TestCase
 
     public function testWithElasticsearchHandler()
     {
-        $configs = array(
-            array(
-                'handlers' => array(
-                    'elasticsearch' => array(
+        $configs = [
+            [
+                'handlers' => [
+                    'elasticsearch' => [
                         'type' => 'elasticsearch',
-                        'elasticsearch' => array(
+                        'elasticsearch' => [
                             'id' => 'elastica.client'
-                        ),
+                        ],
                         'index' => 'my-index',
                         'document_type' => 'my-record',
                         'ignore_error' => true
-                    )
-                )
-            )
-        );
+                    ]
+                ]
+            ]
+        ];
 
         $config = $this->process($configs);
 
@@ -246,49 +246,50 @@ class ConfigurationTest extends TestCase
 
     public function testWithConsoleHandler()
     {
-        $configs = array(
-            array(
-                'handlers' => array(
-                    'console' => array(
+        $configs = [
+            [
+                'handlers' => [
+                    'console' => [
                         'type' => 'console',
-                        'verbosity_levels' => array(
+                        'verbosity_levels' => [
                             'VERBOSITY_NORMAL' => 'NOTICE',
                             'verbosity_verbose' => 'info',
                             'VERBOSITY_very_VERBOSE' => 150
-                        )
-                    )
-                )
-            )
-        );
+                        ]
+                    ]
+                ]
+            ]
+        ];
 
         $config = $this->process($configs);
 
         $this->assertSame('console', $config['handlers']['console']['type']);
-        $this->assertSame(array(
+        $this->assertSame(
+            [
             OutputInterface::VERBOSITY_NORMAL => Logger::NOTICE,
             OutputInterface::VERBOSITY_VERBOSE => Logger::INFO,
             OutputInterface::VERBOSITY_VERY_VERBOSE => 150,
             OutputInterface::VERBOSITY_QUIET => Logger::ERROR,
             OutputInterface::VERBOSITY_DEBUG => Logger::DEBUG
-        ), $config['handlers']['console']['verbosity_levels']);
+            ], $config['handlers']['console']['verbosity_levels']);
     }
 
     public function testWithType()
     {
-        $configs = array(
-            array(
-                'handlers' => array(
-                    'foo' => array(
+        $configs = [
+            [
+                'handlers' => [
+                    'foo' => [
                         'type' => 'stream',
                         'path' => '/foo',
-                        'channels' => array(
+                        'channels' => [
                             'type' => 'inclusive',
-                            'elements' => array('A', 'B')
-                        )
-                    )
-                )
-            )
-        );
+                            'elements' => ['A', 'B']
+                        ]
+                    ]
+                ]
+            ]
+        ];
 
         $config = $this->process($configs);
 
@@ -301,22 +302,22 @@ class ConfigurationTest extends TestCase
 
     public function testWithFilePermission()
     {
-        $configs = array(
-            array(
-                'handlers' => array(
-                    'foo' => array(
+        $configs = [
+            [
+                'handlers' => [
+                    'foo' => [
                         'type' => 'stream',
                         'path' => '/foo',
                         'file_permission' => '0666',
-                    ),
-                    'bar' => array(
+                    ],
+                    'bar' => [
                         'type' => 'stream',
                         'path' => '/bar',
                         'file_permission' => 0777
-                    )
-                )
-            )
-        );
+                    ]
+                ]
+            ]
+        ];
 
         $config = $this->process($configs);
 
@@ -326,22 +327,22 @@ class ConfigurationTest extends TestCase
 
     public function testWithUseLocking()
     {
-        $configs = array(
-            array(
-                'handlers' => array(
-                    'foo' => array(
+        $configs = [
+            [
+                'handlers' => [
+                    'foo' => [
                         'type' => 'stream',
                         'path' => '/foo',
                         'use_locking' => false,
-                    ),
-                    'bar' => array(
+                    ],
+                    'bar' => [
                         'type' => 'stream',
                         'path' => '/bar',
                         'use_locking' => true,
-                    )
-                )
-            )
-        );
+                    ]
+                ]
+            ]
+        ];
 
         $config = $this->process($configs);
 
@@ -351,11 +352,11 @@ class ConfigurationTest extends TestCase
 
     public function testWithNestedHandler()
     {
-        $configs = array(
-            array(
-                'handlers' => array('foobar' => array('type' => 'stream', 'path' => '/foo/bar', 'nested' => true))
-            )
-        );
+        $configs = [
+            [
+                'handlers' => ['foobar' => ['type' => 'stream', 'path' => '/foo/bar', 'nested' => true]]
+            ]
+        ];
 
         $config = $this->process($configs);
 
@@ -364,22 +365,22 @@ class ConfigurationTest extends TestCase
     }
     public function testWithRedisHandler()
     {
-        $configs = array(
-            array(
-                'handlers' => array(
-                    'redis' => array(
+        $configs = [
+            [
+                'handlers' => [
+                    'redis' => [
                         'type' => 'redis',
-                        'redis' => array(
+                        'redis' => [
                             'host' => '127.0.1.1',
                             'password' => 'pa$$w0rd',
                             'port' => 1234,
                             'database' => 1,
                             'key_name' => 'monolog_redis_test'
-                        )
-                    )
-                )
-            )
-        );
+                        ]
+                    ]
+                ]
+            ]
+        ];
         $config = $this->process($configs);
 
         $this->assertEquals('127.0.1.1', $config['handlers']['redis']['redis']['host']);
@@ -388,19 +389,19 @@ class ConfigurationTest extends TestCase
         $this->assertEquals(1, $config['handlers']['redis']['redis']['database']);
         $this->assertEquals('monolog_redis_test', $config['handlers']['redis']['redis']['key_name']);
 
-        $configs = array(
-            array(
-                'handlers' => array(
-                    'redis' => array(
+        $configs = [
+            [
+                'handlers' => [
+                    'redis' => [
                         'type' => 'predis',
-                        'redis' => array(
+                        'redis' => [
                             'host' => '127.0.1.1',
                             'key_name' => 'monolog_redis_test'
-                        )
-                    )
-                )
-            )
-        );
+                        ]
+                    ]
+                ]
+            ]
+        ];
         $config = $this->process($configs);
 
         $this->assertEquals('127.0.1.1', $config['handlers']['redis']['redis']['host']);

--- a/Tests/DependencyInjection/FixtureMonologExtensionTest.php
+++ b/Tests/DependencyInjection/FixtureMonologExtensionTest.php
@@ -145,14 +145,13 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
     {
         $container = $this->getContainer('single_email_recipient');
 
-        $this->assertEquals(
-            [
+        $this->assertEquals([
             new Reference('mailer'),
             'error@example.com', // from
             ['error@example.com'], // to
             'An Error Occurred!', // subject
             null,
-            ], $container->getDefinition('monolog.handler.swift.mail_message_factory')->getArguments());
+        ], $container->getDefinition('monolog.handler.swift.mail_message_factory')->getArguments());
     }
 
     public function testServerLog()
@@ -163,26 +162,24 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
 
         $container = $this->getContainer('server_log');
 
-        $this->assertEquals(
-            [
+        $this->assertEquals([
             '0:9911',
             100,
             true,
-            ], $container->getDefinition('monolog.handler.server_log')->getArguments());
+        ], $container->getDefinition('monolog.handler.server_log')->getArguments());
     }
 
     public function testMultipleEmailRecipients()
     {
         $container = $this->getContainer('multiple_email_recipients');
 
-        $this->assertEquals(
-            [
+        $this->assertEquals([
             new Reference('mailer'),
             'error@example.com',
             ['dev1@example.com', 'dev2@example.com'],
             'An Error Occurred!',
             null
-            ], $container->getDefinition('monolog.handler.swift.mail_message_factory')->getArguments());
+        ], $container->getDefinition('monolog.handler.swift.mail_message_factory')->getArguments());
     }
 
     public function testChannelParametersResolved()

--- a/Tests/DependencyInjection/FixtureMonologExtensionTest.php
+++ b/Tests/DependencyInjection/FixtureMonologExtensionTest.php
@@ -30,22 +30,24 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
 
         $logger = $container->getDefinition('monolog.logger');
         $this->assertCount(4, $logger->getMethodCalls());
-        $this->assertDICDefinitionMethodCallAt(3, $logger, 'pushHandler', array(new Reference('monolog.handler.custom')));
-        $this->assertDICDefinitionMethodCallAt(2, $logger, 'pushHandler', array(new Reference('monolog.handler.main')));
-        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', array(new Reference('monolog.handler.filtered')));
-        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', array('%monolog.use_microseconds%'));
+        $this->assertDICDefinitionMethodCallAt(3, $logger, 'pushHandler', [new Reference('monolog.handler.custom')]);
+        $this->assertDICDefinitionMethodCallAt(2, $logger, 'pushHandler', [new Reference('monolog.handler.main')]);
+        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.filtered')]);
+        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', ['%monolog.use_microseconds%']);
 
         $handler = $container->getDefinition('monolog.handler.custom');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
-        $this->assertDICConstructorArguments($handler, array('/tmp/symfony.log', \Monolog\Logger::ERROR, false, 0666, false));
+        $this->assertDICConstructorArguments($handler, ['/tmp/symfony.log', \Monolog\Logger::ERROR, false, 0666, false]);
 
         $handler = $container->getDefinition('monolog.handler.main');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\FingersCrossedHandler');
-        $this->assertDICConstructorArguments($handler, array(new Reference('monolog.handler.nested'), \Monolog\Logger::ERROR, 0, true, true, \Monolog\Logger::NOTICE));
+        $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested'), \Monolog\Logger::ERROR, 0, true, true, \Monolog\Logger::NOTICE]
+        );
 
         $handler = $container->getDefinition('monolog.handler.filtered');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\FilterHandler');
-        $this->assertDICConstructorArguments($handler, array(new Reference('monolog.handler.nested2'), array(\Monolog\Logger::WARNING, \Monolog\Logger::ERROR), \Monolog\Logger::EMERGENCY, true));
+        $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested2'), [\Monolog\Logger::WARNING, \Monolog\Logger::ERROR], \Monolog\Logger::EMERGENCY, true]
+        );
     }
 
     public function testLoadWithOverwriting()
@@ -59,17 +61,19 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
 
         $logger = $container->getDefinition('monolog.logger');
         $this->assertCount(3, $logger->getMethodCalls());
-        $this->assertDICDefinitionMethodCallAt(2, $logger, 'pushHandler', array(new Reference('monolog.handler.custom')));
-        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', array(new Reference('monolog.handler.main')));
-        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', array('%monolog.use_microseconds%'));
+        $this->assertDICDefinitionMethodCallAt(2, $logger, 'pushHandler', [new Reference('monolog.handler.custom')]);
+        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.main')]);
+        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', ['%monolog.use_microseconds%']);
 
         $handler = $container->getDefinition('monolog.handler.custom');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
-        $this->assertDICConstructorArguments($handler, array('/tmp/symfony.log', \Monolog\Logger::WARNING, true, null, false));
+        $this->assertDICConstructorArguments($handler, ['/tmp/symfony.log', \Monolog\Logger::WARNING, true, null, false]
+        );
 
         $handler = $container->getDefinition('monolog.handler.main');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\FingersCrossedHandler');
-        $this->assertDICConstructorArguments($handler, array(new Reference('monolog.handler.nested'), \Monolog\Logger::ERROR, 0, true, true, null));
+        $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested'), \Monolog\Logger::ERROR, 0, true, true, null]
+        );
     }
 
     public function testLoadWithNewAtEnd()
@@ -84,14 +88,14 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
 
         $logger = $container->getDefinition('monolog.logger');
         $this->assertCount(4, $logger->getMethodCalls());
-        $this->assertDICDefinitionMethodCallAt(3, $logger, 'pushHandler', array(new Reference('monolog.handler.custom')));
-        $this->assertDICDefinitionMethodCallAt(2, $logger, 'pushHandler', array(new Reference('monolog.handler.main')));
-        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', array(new Reference('monolog.handler.new')));
-        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', array('%monolog.use_microseconds%'));
+        $this->assertDICDefinitionMethodCallAt(3, $logger, 'pushHandler', [new Reference('monolog.handler.custom')]);
+        $this->assertDICDefinitionMethodCallAt(2, $logger, 'pushHandler', [new Reference('monolog.handler.main')]);
+        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.new')]);
+        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', ['%monolog.use_microseconds%']);
 
         $handler = $container->getDefinition('monolog.handler.new');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
-        $this->assertDICConstructorArguments($handler, array('/tmp/monolog.log', \Monolog\Logger::ERROR, true, null, false));
+        $this->assertDICConstructorArguments($handler, ['/tmp/monolog.log', \Monolog\Logger::ERROR, true, null, false]);
     }
 
     public function testLoadWithNewAndPriority()
@@ -107,23 +111,24 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
 
         $logger = $container->getDefinition('monolog.logger');
         $this->assertCount(5, $logger->getMethodCalls());
-        $this->assertDICDefinitionMethodCallAt(4, $logger, 'pushHandler', array(new Reference('monolog.handler.first')));
-        $this->assertDICDefinitionMethodCallAt(3, $logger, 'pushHandler', array(new Reference('monolog.handler.custom')));
-        $this->assertDICDefinitionMethodCallAt(2, $logger, 'pushHandler', array(new Reference('monolog.handler.main')));
-        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', array(new Reference('monolog.handler.last')));
-        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', array('%monolog.use_microseconds%'));
+        $this->assertDICDefinitionMethodCallAt(4, $logger, 'pushHandler', [new Reference('monolog.handler.first')]);
+        $this->assertDICDefinitionMethodCallAt(3, $logger, 'pushHandler', [new Reference('monolog.handler.custom')]);
+        $this->assertDICDefinitionMethodCallAt(2, $logger, 'pushHandler', [new Reference('monolog.handler.main')]);
+        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.last')]);
+        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', ['%monolog.use_microseconds%']);
 
         $handler = $container->getDefinition('monolog.handler.main');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\BufferHandler');
-        $this->assertDICConstructorArguments($handler, array(new Reference('monolog.handler.nested'), 0, \Monolog\Logger::INFO, true, false));
+        $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested'), 0, \Monolog\Logger::INFO, true, false]
+        );
 
         $handler = $container->getDefinition('monolog.handler.first');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\RotatingFileHandler');
-        $this->assertDICConstructorArguments($handler, array('/tmp/monolog.log', 0, \Monolog\Logger::ERROR, true, null));
+        $this->assertDICConstructorArguments($handler, ['/tmp/monolog.log', 0, \Monolog\Logger::ERROR, true, null]);
 
         $handler = $container->getDefinition('monolog.handler.last');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
-        $this->assertDICConstructorArguments($handler, array('/tmp/last.log', \Monolog\Logger::ERROR, true, null, false));
+        $this->assertDICConstructorArguments($handler, ['/tmp/last.log', \Monolog\Logger::ERROR, true, null, false]);
     }
 
     public function testHandlersWithChannels()
@@ -131,12 +136,12 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
         $container = $this->getContainer('handlers_with_channels');
 
         $this->assertEquals(
-            array(
-                'monolog.handler.custom' => array('type' => 'inclusive', 'elements' => array('foo')),
-                'monolog.handler.main' => array('type' => 'exclusive', 'elements' => array('foo', 'bar')),
+            [
+                'monolog.handler.custom' => ['type' => 'inclusive', 'elements' => ['foo']],
+                'monolog.handler.main' => ['type' => 'exclusive', 'elements' => ['foo', 'bar']],
                 'monolog.handler.extra' => null,
-                'monolog.handler.more' => array('type' => 'inclusive', 'elements' => array('security', 'doctrine')),
-            ),
+                'monolog.handler.more' => ['type' => 'inclusive', 'elements' => ['security', 'doctrine']],
+            ],
             $container->getParameter('monolog.handlers_to_channels')
         );
     }
@@ -145,13 +150,14 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
     {
         $container = $this->getContainer('single_email_recipient');
 
-        $this->assertEquals(array(
+        $this->assertEquals(
+            [
             new Reference('mailer'),
             'error@example.com', // from
-            array('error@example.com'), // to
+            ['error@example.com'], // to
             'An Error Occurred!', // subject
             null,
-        ), $container->getDefinition('monolog.handler.swift.mail_message_factory')->getArguments());
+            ], $container->getDefinition('monolog.handler.swift.mail_message_factory')->getArguments());
     }
 
     public function testServerLog()
@@ -162,24 +168,26 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
 
         $container = $this->getContainer('server_log');
 
-        $this->assertEquals(array(
+        $this->assertEquals(
+            [
             '0:9911',
             100,
             true,
-        ), $container->getDefinition('monolog.handler.server_log')->getArguments());
+            ], $container->getDefinition('monolog.handler.server_log')->getArguments());
     }
 
     public function testMultipleEmailRecipients()
     {
         $container = $this->getContainer('multiple_email_recipients');
 
-        $this->assertEquals(array(
+        $this->assertEquals(
+            [
             new Reference('mailer'),
             'error@example.com',
-            array('dev1@example.com', 'dev2@example.com'),
+            ['dev1@example.com', 'dev2@example.com'],
             'An Error Occurred!',
             null
-        ), $container->getDefinition('monolog.handler.swift.mail_message_factory')->getArguments());
+            ], $container->getDefinition('monolog.handler.swift.mail_message_factory')->getArguments());
     }
 
     public function testChannelParametersResolved()
@@ -187,9 +195,9 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
         $container = $this->getContainer('parameterized_handlers');
 
         $this->assertEquals(
-            array(
-                'monolog.handler.custom' => array('type' => 'inclusive', 'elements' => array('some_channel')),
-            ),
+            [
+                'monolog.handler.custom' => ['type' => 'inclusive', 'elements' => ['some_channel']],
+            ],
             $container->getParameter('monolog.handlers_to_channels')
         );
     }
@@ -202,7 +210,7 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
 
         $methodCalls = $logger->getMethodCalls();
 
-        $this->assertContains(array('pushProcessor', array(new Reference('monolog.processor.psr_log_message'))), $methodCalls, 'The PSR-3 processor should be enabled', false, false);
+        $this->assertContains(['pushProcessor', [new Reference('monolog.processor.psr_log_message')]], $methodCalls, 'The PSR-3 processor should be enabled', false, false);
     }
 
     public function testPsr3MessageProcessingDisabled()
@@ -213,7 +221,7 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
 
         $methodCalls = $logger->getMethodCalls();
 
-        $this->assertNotContains(array('pushProcessor', array(new Reference('monolog.processor.psr_log_message'))), $methodCalls, 'The PSR-3 processor should not be enabled', false, false);
+        $this->assertNotContains(['pushProcessor', [new Reference('monolog.processor.psr_log_message')]], $methodCalls, 'The PSR-3 processor should not be enabled', false, false);
     }
 
     public function testNativeMailer()
@@ -234,8 +242,8 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
 
         $this->loadFixture($container, $fixture);
 
-        $container->getCompilerPassConfig()->setOptimizationPasses(array());
-        $container->getCompilerPassConfig()->setRemovingPasses(array());
+        $container->getCompilerPassConfig()->setOptimizationPasses([]);
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
         $container->addCompilerPass(new LoggerChannelPass());
         $container->compile();
 

--- a/Tests/DependencyInjection/FixtureMonologExtensionTest.php
+++ b/Tests/DependencyInjection/FixtureMonologExtensionTest.php
@@ -41,13 +41,11 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
 
         $handler = $container->getDefinition('monolog.handler.main');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\FingersCrossedHandler');
-        $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested'), \Monolog\Logger::ERROR, 0, true, true, \Monolog\Logger::NOTICE]
-        );
+        $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested'), \Monolog\Logger::ERROR, 0, true, true, \Monolog\Logger::NOTICE]);
 
         $handler = $container->getDefinition('monolog.handler.filtered');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\FilterHandler');
-        $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested2'), [\Monolog\Logger::WARNING, \Monolog\Logger::ERROR], \Monolog\Logger::EMERGENCY, true]
-        );
+        $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested2'), [\Monolog\Logger::WARNING, \Monolog\Logger::ERROR], \Monolog\Logger::EMERGENCY, true]);
     }
 
     public function testLoadWithOverwriting()
@@ -67,13 +65,11 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
 
         $handler = $container->getDefinition('monolog.handler.custom');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
-        $this->assertDICConstructorArguments($handler, ['/tmp/symfony.log', \Monolog\Logger::WARNING, true, null, false]
-        );
+        $this->assertDICConstructorArguments($handler, ['/tmp/symfony.log', \Monolog\Logger::WARNING, true, null, false]);
 
         $handler = $container->getDefinition('monolog.handler.main');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\FingersCrossedHandler');
-        $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested'), \Monolog\Logger::ERROR, 0, true, true, null]
-        );
+        $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested'), \Monolog\Logger::ERROR, 0, true, true, null]);
     }
 
     public function testLoadWithNewAtEnd()
@@ -119,8 +115,7 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
 
         $handler = $container->getDefinition('monolog.handler.main');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\BufferHandler');
-        $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested'), 0, \Monolog\Logger::INFO, true, false]
-        );
+        $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested'), 0, \Monolog\Logger::INFO, true, false]);
 
         $handler = $container->getDefinition('monolog.handler.first');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\RotatingFileHandler');

--- a/Tests/DependencyInjection/MonologExtensionTest.php
+++ b/Tests/DependencyInjection/MonologExtensionTest.php
@@ -22,63 +22,77 @@ class MonologExtensionTest extends DependencyInjectionTest
 {
     public function testLoadWithDefault()
     {
-        $container = $this->getContainer(array(array('handlers' => array('main' => array('type' => 'stream')))));
+        $container = $this->getContainer([['handlers' => ['main' => ['type' => 'stream']]]]);
 
         $this->assertTrue($container->hasDefinition('monolog.logger'));
         $this->assertTrue($container->hasDefinition('monolog.handler.main'));
 
         $logger = $container->getDefinition('monolog.logger');
-        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', array('%monolog.use_microseconds%'));
-        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', array(new Reference('monolog.handler.main')));
+        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', ['%monolog.use_microseconds%']);
+        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.main')]);
 
         $handler = $container->getDefinition('monolog.handler.main');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
-        $this->assertDICConstructorArguments($handler, array('%kernel.logs_dir%/%kernel.environment%.log', \Monolog\Logger::DEBUG, true, null, false));
-        $this->assertDICDefinitionMethodCallAt(0, $handler, 'pushProcessor', array(new Reference('monolog.processor.psr_log_message')));
+        $this->assertDICConstructorArguments($handler, ['%kernel.logs_dir%/%kernel.environment%.log', \Monolog\Logger::DEBUG, true, null, false]
+        );
+        $this->assertDICDefinitionMethodCallAt(0, $handler, 'pushProcessor', [new Reference('monolog.processor.psr_log_message')]
+        );
     }
 
     public function testLoadWithCustomValues()
     {
-        $container = $this->getContainer(array(array('handlers' => array(
-            'custom' => array('type' => 'stream', 'path' => '/tmp/symfony.log', 'bubble' => false, 'level' => 'ERROR', 'file_permission' => '0666', 'use_locking' => true)
-        ))));
+        $container = $this->getContainer(
+            [
+                [
+                    'handlers' => [
+            'custom' => ['type' => 'stream', 'path' => '/tmp/symfony.log', 'bubble' => false, 'level' => 'ERROR', 'file_permission' => '0666', 'use_locking' => true]
+                    ]
+                ]
+            ]
+        );
         $this->assertTrue($container->hasDefinition('monolog.logger'));
         $this->assertTrue($container->hasDefinition('monolog.handler.custom'));
 
         $logger = $container->getDefinition('monolog.logger');
-        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', array('%monolog.use_microseconds%'));
-        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', array(new Reference('monolog.handler.custom')));
+        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', ['%monolog.use_microseconds%']);
+        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.custom')]);
 
         $handler = $container->getDefinition('monolog.handler.custom');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
-        $this->assertDICConstructorArguments($handler, array('/tmp/symfony.log', \Monolog\Logger::ERROR, false, 0666, true));
+        $this->assertDICConstructorArguments($handler, ['/tmp/symfony.log', \Monolog\Logger::ERROR, false, 0666, true]);
     }
 
     public function testLoadWithNestedHandler()
     {
-        $container = $this->getContainer(array(array('handlers' => array(
-            'custom' => array('type' => 'stream', 'path' => '/tmp/symfony.log', 'bubble' => false, 'level' => 'ERROR', 'file_permission' => '0666'),
-            'nested' => array('type' => 'stream', 'path' => '/tmp/symfony.log', 'bubble' => false, 'level' => 'ERROR', 'file_permission' => '0666', 'nested' => true)
-        ))));
+        $container = $this->getContainer(
+            [
+                [
+                    'handlers' => [
+            'custom' => ['type' => 'stream', 'path' => '/tmp/symfony.log', 'bubble' => false, 'level' => 'ERROR', 'file_permission' => '0666'],
+            'nested' => ['type' => 'stream', 'path' => '/tmp/symfony.log', 'bubble' => false, 'level' => 'ERROR', 'file_permission' => '0666', 'nested' => true]
+                    ]
+                ]
+            ]
+        );
         $this->assertTrue($container->hasDefinition('monolog.logger'));
         $this->assertTrue($container->hasDefinition('monolog.handler.custom'));
         $this->assertTrue($container->hasDefinition('monolog.handler.nested'));
 
         $logger = $container->getDefinition('monolog.logger');
         // Nested handler must not be pushed to logger
-        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', array('%monolog.use_microseconds%'));
-        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', array(new Reference('monolog.handler.custom')));
+        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', ['%monolog.use_microseconds%']);
+        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.custom')]);
 
         $handler = $container->getDefinition('monolog.handler.custom');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
-        $this->assertDICConstructorArguments($handler, array('/tmp/symfony.log', \Monolog\Logger::ERROR, false, 0666, false));
+        $this->assertDICConstructorArguments($handler, ['/tmp/symfony.log', \Monolog\Logger::ERROR, false, 0666, false]);
     }
 
     public function testLoadWithServiceHandler()
     {
         $container = $this->getContainer(
-            array(array('handlers' => array('custom' => array('type' => 'service', 'id' => 'some.service.id')))),
-            array('some.service.id' => new Definition('stdClass', array('foo', false)))
+            [['handlers' => ['custom' => ['type' => 'service', 'id' => 'some.service.id']]]],
+            ['some.service.id' => new Definition('stdClass', ['foo', false])]
         );
 
         $this->assertTrue($container->hasDefinition('monolog.logger'));
@@ -86,19 +100,19 @@ class MonologExtensionTest extends DependencyInjectionTest
 
         $logger = $container->getDefinition('monolog.logger');
         // Custom service handler must be pushed to logger
-        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', array('%monolog.use_microseconds%'));
-        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', array(new Reference('monolog.handler.custom')));
+        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', ['%monolog.use_microseconds%']);
+        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.custom')]);
 
         $handler = $container->findDefinition('monolog.handler.custom');
         $this->assertDICDefinitionClass($handler, 'stdClass');
-        $this->assertDICConstructorArguments($handler, array('foo', false));
+        $this->assertDICConstructorArguments($handler, ['foo', false]);
     }
 
     public function testLoadWithNestedServiceHandler()
     {
         $container = $this->getContainer(
-            array(array('handlers' => array('custom' => array('type' => 'service', 'id' => 'some.service.id', 'nested' => true)))),
-            array('some.service.id' => new Definition('stdClass', array('foo', false)))
+            [['handlers' => ['custom' => ['type' => 'service', 'id' => 'some.service.id', 'nested' => true]]]],
+            ['some.service.id' => new Definition('stdClass', ['foo', false])]
         );
 
         $this->assertTrue($container->hasDefinition('monolog.logger'));
@@ -107,11 +121,11 @@ class MonologExtensionTest extends DependencyInjectionTest
         $logger = $container->getDefinition('monolog.logger');
         // Nested service handler must not be pushed to logger
         $this->assertCount(1, $logger->getMethodCalls());
-        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', array('%monolog.use_microseconds%'));
+        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', ['%monolog.use_microseconds%']);
 
         $handler = $container->findDefinition('monolog.handler.custom');
         $this->assertDICDefinitionClass($handler, 'stdClass');
-        $this->assertDICConstructorArguments($handler, array('foo', false));
+        $this->assertDICConstructorArguments($handler, ['foo', false]);
     }
 
     /**
@@ -122,7 +136,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         $container = new ContainerBuilder();
         $loader = new MonologExtension();
 
-        $loader->load(array(array('handlers' => array('main' => array('type' => 'invalid_handler')))), $container);
+        $loader->load([['handlers' => ['main' => ['type' => 'invalid_handler']]]], $container);
     }
 
     /**
@@ -133,7 +147,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         $container = new ContainerBuilder();
         $loader = new MonologExtension();
 
-        $loader->load(array(array('handlers' => array('main' => array('type' => 'fingers_crossed')))), $container);
+        $loader->load([['handlers' => ['main' => ['type' => 'fingers_crossed']]]], $container);
     }
 
     /**
@@ -144,7 +158,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         $container = new ContainerBuilder();
         $loader = new MonologExtension();
 
-        $loader->load(array(array('handlers' => array('main' => array('type' => 'filter')))), $container);
+        $loader->load([['handlers' => ['main' => ['type' => 'filter']]]], $container);
     }
 
     /**
@@ -155,7 +169,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         $container = new ContainerBuilder();
         $loader = new MonologExtension();
 
-        $loader->load(array(array('handlers' => array('main' => array('type' => 'buffer')))), $container);
+        $loader->load([['handlers' => ['main' => ['type' => 'buffer']]]], $container);
     }
 
     /**
@@ -166,7 +180,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         $container = new ContainerBuilder();
         $loader = new MonologExtension();
 
-        $loader->load(array(array('handlers' => array('gelf' => array('type' => 'gelf')))), $container);
+        $loader->load([['handlers' => ['gelf' => ['type' => 'gelf']]]], $container);
     }
 
     /**
@@ -177,7 +191,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         $container = new ContainerBuilder();
         $loader = new MonologExtension();
 
-        $loader->load(array(array('handlers' => array('gelf' => array('type' => 'gelf', 'publisher' => array())))), $container);
+        $loader->load([['handlers' => ['gelf' => ['type' => 'gelf', 'publisher' => []]]]], $container);
     }
 
     /**
@@ -188,7 +202,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         $container = new ContainerBuilder();
         $loader = new MonologExtension();
 
-        $loader->load(array(array('handlers' => array('main' => array('type' => 'service')))), $container);
+        $loader->load([['handlers' => ['main' => ['type' => 'service']]]], $container);
     }
 
     /**
@@ -200,90 +214,100 @@ class MonologExtensionTest extends DependencyInjectionTest
         $container = new ContainerBuilder();
         $loader = new MonologExtension();
 
-        $loader->load(array(array('handlers' => array('debug' => array('type' => 'stream')))), $container);
+        $loader->load([['handlers' => ['debug' => ['type' => 'stream']]]], $container);
     }
 
     public function testSyslogHandlerWithLogopts()
     {
-        $container = $this->getContainer(array(array('handlers' => array('main' => array('type' => 'syslog', 'logopts' => LOG_CONS)))));
+        $container = $this->getContainer([['handlers' => ['main' => ['type' => 'syslog', 'logopts' => LOG_CONS]]]]);
 
         $this->assertTrue($container->hasDefinition('monolog.logger'));
         $this->assertTrue($container->hasDefinition('monolog.handler.main'));
 
         $logger = $container->getDefinition('monolog.logger');
-        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', array('%monolog.use_microseconds%'));
-        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', array(new Reference('monolog.handler.main')));
+        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', ['%monolog.use_microseconds%']);
+        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.main')]);
 
         $handler = $container->getDefinition('monolog.handler.main');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\SyslogHandler');
-        $this->assertDICConstructorArguments($handler, array(false, 'user', \Monolog\Logger::DEBUG, true, LOG_CONS));
+        $this->assertDICConstructorArguments($handler, [false, 'user', \Monolog\Logger::DEBUG, true, LOG_CONS]);
     }
 
     public function testRollbarHandlerCreatesNotifier()
     {
-        $container = $this->getContainer(array(array('handlers' => array('main' => array('type' => 'rollbar', 'token' => 'MY_TOKEN')))));
+        $container = $this->getContainer([['handlers' => ['main' => ['type' => 'rollbar', 'token' => 'MY_TOKEN']]]]);
 
         $this->assertTrue($container->hasDefinition('monolog.logger'));
         $this->assertTrue($container->hasDefinition('monolog.handler.main'));
 
         $logger = $container->getDefinition('monolog.logger');
-        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', array('%monolog.use_microseconds%'));
-        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', array(new Reference('monolog.handler.main')));
+        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', ['%monolog.use_microseconds%']);
+        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.main')]);
 
         $handler = $container->getDefinition('monolog.handler.main');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\RollbarHandler');
-        $this->assertDICConstructorArguments($handler, array(new Reference('monolog.rollbar.notifier.1c8e6a67728dff6a209f828427128dd8b3c2b746'), \Monolog\Logger::DEBUG, true));
+        $this->assertDICConstructorArguments($handler, [new Reference('monolog.rollbar.notifier.1c8e6a67728dff6a209f828427128dd8b3c2b746'), \Monolog\Logger::DEBUG, true]
+        );
     }
 
     public function testRollbarHandlerReusesNotifier()
     {
-        $container = $this->getContainer(array(array('handlers' => array('main' => array('type' => 'rollbar', 'id' => 'my_rollbar_id')))));
+        $container = $this->getContainer([['handlers' => ['main' => ['type' => 'rollbar', 'id' => 'my_rollbar_id']]]]);
 
         $this->assertTrue($container->hasDefinition('monolog.logger'));
         $this->assertTrue($container->hasDefinition('monolog.handler.main'));
 
         $logger = $container->getDefinition('monolog.logger');
-        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', array('%monolog.use_microseconds%'));
-        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', array(new Reference('monolog.handler.main')));
+        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', ['%monolog.use_microseconds%']);
+        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.main')]);
 
         $handler = $container->getDefinition('monolog.handler.main');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\RollbarHandler');
-        $this->assertDICConstructorArguments($handler, array(new Reference('my_rollbar_id'), \Monolog\Logger::DEBUG, true));
+        $this->assertDICConstructorArguments($handler, [new Reference('my_rollbar_id'), \Monolog\Logger::DEBUG, true]);
     }
 
     public function testSocketHandler()
     {
         try {
-            $this->getContainer(array(array('handlers' => array('socket' => array('type' => 'socket')))));
+            $this->getContainer([['handlers' => ['socket' => ['type' => 'socket']]]]);
             $this->fail();
         } catch (InvalidConfigurationException $e) {
             $this->assertContains('connection_string', $e->getMessage());
         }
 
-        $container = $this->getContainer(array(array('handlers' => array('socket' => array(
+        $container = $this->getContainer(
+            [
+                [
+                    'handlers' => [
+                        'socket' => [
             'type' => 'socket', 'timeout' => 1, 'persistent' => true,
-            'connection_string' => 'localhost:50505', 'connection_timeout' => '0.6')
-        ))));
+            'connection_string' => 'localhost:50505', 'connection_timeout' => '0.6'
+                        ]
+                    ]
+                ]
+            ]
+        );
         $this->assertTrue($container->hasDefinition('monolog.logger'));
         $this->assertTrue($container->hasDefinition('monolog.handler.socket'));
 
         $logger = $container->getDefinition('monolog.logger');
-        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', array('%monolog.use_microseconds%'));
-        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', array(new Reference('monolog.handler.socket')));
+        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', ['%monolog.use_microseconds%']);
+        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.socket')]);
 
         $handler = $container->getDefinition('monolog.handler.socket');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\SocketHandler');
-        $this->assertDICConstructorArguments($handler, array('localhost:50505', \Monolog\Logger::DEBUG, true));
-        $this->assertDICDefinitionMethodCallAt(0, $handler, 'pushProcessor', array(new Reference('monolog.processor.psr_log_message')));
-        $this->assertDICDefinitionMethodCallAt(1, $handler, 'setTimeout', array('1'));
-        $this->assertDICDefinitionMethodCallAt(2, $handler, 'setConnectionTimeout', array('0.6'));
-        $this->assertDICDefinitionMethodCallAt(3, $handler, 'setPersistent', array(true));
+        $this->assertDICConstructorArguments($handler, ['localhost:50505', \Monolog\Logger::DEBUG, true]);
+        $this->assertDICDefinitionMethodCallAt(0, $handler, 'pushProcessor', [new Reference('monolog.processor.psr_log_message')]
+        );
+        $this->assertDICDefinitionMethodCallAt(1, $handler, 'setTimeout', ['1']);
+        $this->assertDICDefinitionMethodCallAt(2, $handler, 'setConnectionTimeout', ['0.6']);
+        $this->assertDICDefinitionMethodCallAt(3, $handler, 'setPersistent', [true]);
     }
 
     public function testRavenHandlerWhenConfigurationIsWrong()
     {
         try {
-            $this->getContainer(array(array('handlers' => array('raven' => array('type' => 'raven')))));
+            $this->getContainer([['handlers' => ['raven' => ['type' => 'raven']]]]);
             $this->fail();
         } catch (InvalidConfigurationException $e) {
             $this->assertContains('DSN', $e->getMessage());
@@ -294,15 +318,23 @@ class MonologExtensionTest extends DependencyInjectionTest
     {
         $dsn = 'http://43f6017361224d098402974103bfc53d:a6a0538fc2934ba2bed32e08741b2cd3@marca.python.live.cheggnet.com:9000/1';
 
-        $container = $this->getContainer(array(array('handlers' => array('raven' => array(
-            'type' => 'raven', 'dsn' => $dsn)
-        ))));
+        $container = $this->getContainer(
+            [
+                [
+                    'handlers' => [
+                        'raven' => [
+            'type' => 'raven', 'dsn' => $dsn
+                        ]
+                    ]
+                ]
+            ]
+        );
         $this->assertTrue($container->hasDefinition('monolog.logger'));
         $this->assertTrue($container->hasDefinition('monolog.handler.raven'));
 
         $logger = $container->getDefinition('monolog.logger');
-        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', array('%monolog.use_microseconds%'));
-        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', array(new Reference('monolog.handler.raven')));
+        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', ['%monolog.use_microseconds%']);
+        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.raven')]);
 
         $this->assertTrue($container->hasDefinition('monolog.raven.client.'.sha1($dsn)));
 
@@ -312,40 +344,56 @@ class MonologExtensionTest extends DependencyInjectionTest
 
     public function testRavenHandlerWhenADSNAndAClientAreSpecified()
     {
-        $container = $this->getContainer(array(array('handlers' => array('raven' => array(
-            'type' => 'raven', 'dsn' => 'foobar', 'client_id' => 'raven.client')
-        ))));
+        $container = $this->getContainer(
+            [
+                [
+                    'handlers' => [
+                        'raven' => [
+            'type' => 'raven', 'dsn' => 'foobar', 'client_id' => 'raven.client'
+                        ]
+                    ]
+                ]
+            ]
+        );
 
         $this->assertFalse($container->hasDefinition('raven.client'));
 
         $logger = $container->getDefinition('monolog.logger');
-        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', array('%monolog.use_microseconds%'));
-        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', array(new Reference('monolog.handler.raven')));
+        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', ['%monolog.use_microseconds%']);
+        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.raven')]);
 
         $handler = $container->getDefinition('monolog.handler.raven');
-        $this->assertDICConstructorArguments($handler, array(new Reference('raven.client'), 100, true));
+        $this->assertDICConstructorArguments($handler, [new Reference('raven.client'), 100, true]);
     }
 
     public function testRavenHandlerWhenAClientIsSpecified()
     {
-        $container = $this->getContainer(array(array('handlers' => array('raven' => array(
-            'type' => 'raven', 'client_id' => 'raven.client')
-        ))));
+        $container = $this->getContainer(
+            [
+                [
+                    'handlers' => [
+                        'raven' => [
+            'type' => 'raven', 'client_id' => 'raven.client'
+                        ]
+                    ]
+                ]
+            ]
+        );
 
         $this->assertFalse($container->hasDefinition('raven.client'));
 
         $logger = $container->getDefinition('monolog.logger');
-        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', array('%monolog.use_microseconds%'));
-        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', array(new Reference('monolog.handler.raven')));
+        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', ['%monolog.use_microseconds%']);
+        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.raven')]);
 
         $handler = $container->getDefinition('monolog.handler.raven');
-        $this->assertDICConstructorArguments($handler, array(new Reference('raven.client'), 100, true));
+        $this->assertDICConstructorArguments($handler, [new Reference('raven.client'), 100, true]);
     }
 
     public function testSentryHandlerWhenConfigurationIsWrong()
     {
         try {
-            $this->getContainer(array(array('handlers' => array('sentry' => array('type' => 'sentry')))));
+            $this->getContainer([['handlers' => ['sentry' => ['type' => 'sentry']]]]);
             $this->fail();
         } catch (InvalidConfigurationException $e) {
             $this->assertContains('DSN', $e->getMessage());
@@ -356,15 +404,23 @@ class MonologExtensionTest extends DependencyInjectionTest
     {
         $dsn = 'http://43f6017361224d098402974103bfc53d:a6a0538fc2934ba2bed32e08741b2cd3@marca.python.live.cheggnet.com:9000/1';
 
-        $container = $this->getContainer(array(array('handlers' => array('sentry' => array(
-            'type' => 'sentry', 'dsn' => $dsn)
-        ))));
+        $container = $this->getContainer(
+            [
+                [
+                    'handlers' => [
+                        'sentry' => [
+            'type' => 'sentry', 'dsn' => $dsn
+                        ]
+                    ]
+                ]
+            ]
+        );
         $this->assertTrue($container->hasDefinition('monolog.logger'));
         $this->assertTrue($container->hasDefinition('monolog.handler.sentry'));
 
         $logger = $container->getDefinition('monolog.logger');
-        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', array('%monolog.use_microseconds%'));
-        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', array(new Reference('monolog.handler.sentry')));
+        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', ['%monolog.use_microseconds%']);
+        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.sentry')]);
 
         $handler = $container->getDefinition('monolog.handler.sentry');
         $this->assertDICDefinitionClass($handler, 'Sentry\Monolog\Handler');
@@ -373,105 +429,137 @@ class MonologExtensionTest extends DependencyInjectionTest
     public function testSentryHandlerWhenADSNAndAClientAreSpecified()
     {
         $container = $this->getContainer(
-            array(
-                array(
-                    'handlers' => array(
-                        'sentry' => array(
+            [
+                [
+                    'handlers' => [
+                        'sentry' => [
                             'type' => 'sentry',
                             'dsn' => 'foobar',
                             'client_id' => 'sentry.client',
-                        ),
-                    ),
-                ),
-            ),
-            array(
+                        ],
+                    ],
+                ],
+            ],
+            [
                 'sentry.client' => new Definition('Sentry\Client'),
-            )
+            ]
         );
 
         $logger = $container->getDefinition('monolog.logger');
-        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', array('%monolog.use_microseconds%'));
-        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', array(new Reference('monolog.handler.sentry')));
+        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', ['%monolog.use_microseconds%']);
+        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.sentry')]);
 
         $handler = $container->getDefinition('monolog.handler.sentry');
-        $this->assertDICConstructorArguments($handler->getArguments()[0], array(new Reference('sentry.client')));
+        $this->assertDICConstructorArguments($handler->getArguments()[0], [new Reference('sentry.client')]);
     }
 
     public function testSentryHandlerWhenAClientIsSpecified()
     {
         $container = $this->getContainer(
-            array(
-                array(
-                    'handlers' => array(
-                        'sentry' => array(
+            [
+                [
+                    'handlers' => [
+                        'sentry' => [
                             'type' =>
                             'sentry',
                             'client_id' => 'sentry.client',
-                        ),
-                    ),
-                ),
-            ),
-            array(
+                        ],
+                    ],
+                ],
+            ],
+            [
                 'sentry.client' => new Definition('Sentry\Client'),
-            )
+            ]
         );
 
         $logger = $container->getDefinition('monolog.logger');
-        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', array('%monolog.use_microseconds%'));
-        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', array(new Reference('monolog.handler.sentry')));
+        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', ['%monolog.use_microseconds%']);
+        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.sentry')]);
 
         $handler = $container->getDefinition('monolog.handler.sentry');
-        $this->assertDICConstructorArguments($handler->getArguments()[0], array(new Reference('sentry.client')));
+        $this->assertDICConstructorArguments($handler->getArguments()[0], [new Reference('sentry.client')]);
     }
 
     public function testLogglyHandler()
     {
         $token = '026308d8-2b63-4225-8fe9-e01294b6e472';
         try {
-            $this->getContainer(array(array('handlers' => array('loggly' => array('type' => 'loggly')))));
+            $this->getContainer([['handlers' => ['loggly' => ['type' => 'loggly']]]]);
             $this->fail();
         } catch (InvalidConfigurationException $e) {
             $this->assertContains('token', $e->getMessage());
         }
 
         try {
-            $this->getContainer(array(array('handlers' => array('loggly' => array(
-                'type' => 'loggly', 'token' => $token, 'tags' => 'x, 1zone ,www.loggly.com,-us,apache$')
-            ))));
+            $this->getContainer(
+                [
+                    [
+                        'handlers' => [
+                            'loggly' => [
+                'type' => 'loggly', 'token' => $token, 'tags' => 'x, 1zone ,www.loggly.com,-us,apache$'
+                            ]
+                        ]
+                    ]
+                ]
+            );
             $this->fail();
         } catch (InvalidConfigurationException $e) {
             $this->assertContains('-us, apache$', $e->getMessage());
         }
 
-        $container = $this->getContainer(array(array('handlers' => array('loggly' => array(
-            'type' => 'loggly', 'token' => $token)
-        ))));
+        $container = $this->getContainer(
+            [
+                [
+                    'handlers' => [
+                        'loggly' => [
+            'type' => 'loggly', 'token' => $token
+                        ]
+                    ]
+                ]
+            ]
+        );
         $this->assertTrue($container->hasDefinition('monolog.logger'));
         $this->assertTrue($container->hasDefinition('monolog.handler.loggly'));
 
         $logger = $container->getDefinition('monolog.logger');
-        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', array('%monolog.use_microseconds%'));
-        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', array(new Reference('monolog.handler.loggly')));
+        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', ['%monolog.use_microseconds%']);
+        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.loggly')]);
         $handler = $container->getDefinition('monolog.handler.loggly');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\LogglyHandler');
-        $this->assertDICConstructorArguments($handler, array($token, \Monolog\Logger::DEBUG, true));
-        $this->assertDICDefinitionMethodCallAt(0, $handler, 'pushProcessor', array(new Reference('monolog.processor.psr_log_message')));
+        $this->assertDICConstructorArguments($handler, [$token, \Monolog\Logger::DEBUG, true]);
+        $this->assertDICDefinitionMethodCallAt(0, $handler, 'pushProcessor', [new Reference('monolog.processor.psr_log_message')]
+        );
 
-        $container = $this->getContainer(array(array('handlers' => array('loggly' => array(
-            'type' => 'loggly', 'token' => $token, 'tags' => array(' ', 'foo', '', 'bar'))
-        ))));
+        $container = $this->getContainer(
+            [
+                [
+                    'handlers' => [
+                        'loggly' => [
+            'type' => 'loggly', 'token' => $token, 'tags' => [' ', 'foo', '', 'bar']
+                        ]
+                    ]
+                ]
+            ]
+        );
         $handler = $container->getDefinition('monolog.handler.loggly');
-        $this->assertDICDefinitionMethodCallAt(0, $handler, 'pushProcessor', array(new Reference('monolog.processor.psr_log_message')));
-        $this->assertDICDefinitionMethodCallAt(1, $handler, 'setTag', array('foo,bar'));
+        $this->assertDICDefinitionMethodCallAt(0, $handler, 'pushProcessor', [new Reference('monolog.processor.psr_log_message')]
+        );
+        $this->assertDICDefinitionMethodCallAt(1, $handler, 'setTag', ['foo,bar']);
     }
 
     /** @group legacy */
     public function testFingersCrossedHandlerWhenExcluded404sAreSpecified()
     {
-        $container = $this->getContainer(array(array('handlers' => array(
-            'main' => array('type' => 'fingers_crossed', 'handler' => 'nested', 'excluded_404s' => array('^/foo', '^/bar')),
-            'nested' => array('type' => 'stream', 'path' => '/tmp/symfony.log')
-        ))));
+        $container = $this->getContainer(
+            [
+                [
+                    'handlers' => [
+            'main' => ['type' => 'fingers_crossed', 'handler' => 'nested', 'excluded_404s' => ['^/foo', '^/bar']],
+            'nested' => ['type' => 'stream', 'path' => '/tmp/symfony.log']
+                    ]
+                ]
+            ]
+        );
 
         $this->assertTrue($container->hasDefinition('monolog.logger'));
         $this->assertTrue($container->hasDefinition('monolog.handler.main'));
@@ -479,16 +567,18 @@ class MonologExtensionTest extends DependencyInjectionTest
         $this->assertTrue($container->hasDefinition('monolog.handler.main.not_found_strategy'));
 
         $logger = $container->getDefinition('monolog.logger');
-        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', array('%monolog.use_microseconds%'));
-        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', array(new Reference('monolog.handler.main')));
+        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', ['%monolog.use_microseconds%']);
+        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.main')]);
 
         $strategy = $container->getDefinition('monolog.handler.main.not_found_strategy');
         $this->assertDICDefinitionClass($strategy, 'Symfony\Bridge\Monolog\Handler\FingersCrossed\NotFoundActivationStrategy');
-        $this->assertDICConstructorArguments($strategy, array(new Reference('request_stack'), array('^/foo', '^/bar'), \Monolog\Logger::WARNING));
+        $this->assertDICConstructorArguments($strategy, [new Reference('request_stack'), ['^/foo', '^/bar'], \Monolog\Logger::WARNING]
+        );
 
         $handler = $container->getDefinition('monolog.handler.main');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\FingersCrossedHandler');
-        $this->assertDICConstructorArguments($handler, array(new Reference('monolog.handler.nested'), new Reference('monolog.handler.main.not_found_strategy'), 0, true, true, null));
+        $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested'), new Reference('monolog.handler.main.not_found_strategy'), 0, true, true, null]
+        );
     }
 
     public function testFingersCrossedHandlerWhenExcludedHttpCodesAreSpecified()
@@ -497,14 +587,20 @@ class MonologExtensionTest extends DependencyInjectionTest
             $this->markTestSkipped('Symfony Monolog 4.1+ is needed.');
         }
 
-        $container = $this->getContainer(array(array('handlers' => array(
-            'main' => array(
+        $container = $this->getContainer(
+            [
+                [
+                    'handlers' => [
+            'main' => [
                 'type' => 'fingers_crossed',
                 'handler' => 'nested',
-                'excluded_http_codes' => array(403, 404, array(405 => array('^/foo', '^/bar')))
-            ),
-            'nested' => array('type' => 'stream', 'path' => '/tmp/symfony.log')
-        ))));
+                'excluded_http_codes' => [403, 404, [405 => ['^/foo', '^/bar']]]
+            ],
+            'nested' => ['type' => 'stream', 'path' => '/tmp/symfony.log']
+                    ]
+                ]
+            ]
+        );
 
         $this->assertTrue($container->hasDefinition('monolog.logger'));
         $this->assertTrue($container->hasDefinition('monolog.handler.main'));
@@ -512,35 +608,37 @@ class MonologExtensionTest extends DependencyInjectionTest
         $this->assertTrue($container->hasDefinition('monolog.handler.main.http_code_strategy'));
 
         $logger = $container->getDefinition('monolog.logger');
-        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', array('%monolog.use_microseconds%'));
-        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', array(new Reference('monolog.handler.main')));
+        $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', ['%monolog.use_microseconds%']);
+        $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.main')]);
 
         $strategy = $container->getDefinition('monolog.handler.main.http_code_strategy');
         $this->assertDICDefinitionClass($strategy, 'Symfony\Bridge\Monolog\Handler\FingersCrossed\HttpCodeActivationStrategy');
-        $this->assertDICConstructorArguments($strategy, array(
+        $this->assertDICConstructorArguments($strategy, [
             new Reference('request_stack'),
-            array(
-                array('code' => 403, 'urls' => array()),
-                array('code' => 404, 'urls' => array()),
-                array('code' => 405, 'urls' => array('^/foo', '^/bar'))
-            ),
+            [
+                ['code' => 403, 'urls' => []],
+                ['code' => 404, 'urls' => []],
+                ['code' => 405, 'urls' => ['^/foo', '^/bar']]
+            ],
             \Monolog\Logger::WARNING
-        ));
+        ]
+        );
 
         $handler = $container->getDefinition('monolog.handler.main');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\FingersCrossedHandler');
-        $this->assertDICConstructorArguments($handler, array(new Reference('monolog.handler.nested'), new Reference('monolog.handler.main.http_code_strategy'), 0, true, true, null));
+        $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested'), new Reference('monolog.handler.main.http_code_strategy'), 0, true, true, null]
+        );
     }
 
-    protected function getContainer(array $config = array(), array $thirdPartyDefinitions = array())
+    protected function getContainer(array $config = [], array $thirdPartyDefinitions = [])
     {
         $container = new ContainerBuilder();
         foreach ($thirdPartyDefinitions as $id => $definition) {
             $container->setDefinition($id, $definition);
         }
 
-        $container->getCompilerPassConfig()->setOptimizationPasses(array());
-        $container->getCompilerPassConfig()->setRemovingPasses(array());
+        $container->getCompilerPassConfig()->setOptimizationPasses([]);
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
         $container->addCompilerPass(new LoggerChannelPass());
 
         $loader = new MonologExtension();

--- a/Tests/DependencyInjection/MonologExtensionTest.php
+++ b/Tests/DependencyInjection/MonologExtensionTest.php
@@ -525,8 +525,7 @@ class MonologExtensionTest extends DependencyInjectionTest
                 ['code' => 405, 'urls' => ['^/foo', '^/bar']]
             ],
             \Monolog\Logger::WARNING
-        ]
-        );
+        ]);
 
         $handler = $container->getDefinition('monolog.handler.main');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\FingersCrossedHandler');

--- a/Tests/DependencyInjection/MonologExtensionTest.php
+++ b/Tests/DependencyInjection/MonologExtensionTest.php
@@ -232,8 +232,7 @@ class MonologExtensionTest extends DependencyInjectionTest
 
         $handler = $container->getDefinition('monolog.handler.main');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\RollbarHandler');
-        $this->assertDICConstructorArguments($handler, [new Reference('monolog.rollbar.notifier.1c8e6a67728dff6a209f828427128dd8b3c2b746'), \Monolog\Logger::DEBUG, true]
-        );
+        $this->assertDICConstructorArguments($handler, [new Reference('monolog.rollbar.notifier.1c8e6a67728dff6a209f828427128dd8b3c2b746'), \Monolog\Logger::DEBUG, true]);
     }
 
     public function testRollbarHandlerReusesNotifier()
@@ -456,15 +455,13 @@ class MonologExtensionTest extends DependencyInjectionTest
         $handler = $container->getDefinition('monolog.handler.loggly');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\LogglyHandler');
         $this->assertDICConstructorArguments($handler, [$token, \Monolog\Logger::DEBUG, true]);
-        $this->assertDICDefinitionMethodCallAt(0, $handler, 'pushProcessor', [new Reference('monolog.processor.psr_log_message')]
-        );
+        $this->assertDICDefinitionMethodCallAt(0, $handler, 'pushProcessor', [new Reference('monolog.processor.psr_log_message')]);
 
         $container = $this->getContainer([['handlers' => ['loggly' => [
             'type' => 'loggly', 'token' => $token, 'tags' => [' ', 'foo', '', 'bar']
         ]]]]);
         $handler = $container->getDefinition('monolog.handler.loggly');
-        $this->assertDICDefinitionMethodCallAt(0, $handler, 'pushProcessor', [new Reference('monolog.processor.psr_log_message')]
-        );
+        $this->assertDICDefinitionMethodCallAt(0, $handler, 'pushProcessor', [new Reference('monolog.processor.psr_log_message')]);
         $this->assertDICDefinitionMethodCallAt(1, $handler, 'setTag', ['foo,bar']);
     }
 
@@ -487,13 +484,11 @@ class MonologExtensionTest extends DependencyInjectionTest
 
         $strategy = $container->getDefinition('monolog.handler.main.not_found_strategy');
         $this->assertDICDefinitionClass($strategy, 'Symfony\Bridge\Monolog\Handler\FingersCrossed\NotFoundActivationStrategy');
-        $this->assertDICConstructorArguments($strategy, [new Reference('request_stack'), ['^/foo', '^/bar'], \Monolog\Logger::WARNING]
-        );
+        $this->assertDICConstructorArguments($strategy, [new Reference('request_stack'), ['^/foo', '^/bar'], \Monolog\Logger::WARNING]);
 
         $handler = $container->getDefinition('monolog.handler.main');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\FingersCrossedHandler');
-        $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested'), new Reference('monolog.handler.main.not_found_strategy'), 0, true, true, null]
-        );
+        $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested'), new Reference('monolog.handler.main.not_found_strategy'), 0, true, true, null]);
     }
 
     public function testFingersCrossedHandlerWhenExcludedHttpCodesAreSpecified()
@@ -535,8 +530,7 @@ class MonologExtensionTest extends DependencyInjectionTest
 
         $handler = $container->getDefinition('monolog.handler.main');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\FingersCrossedHandler');
-        $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested'), new Reference('monolog.handler.main.http_code_strategy'), 0, true, true, null]
-        );
+        $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested'), new Reference('monolog.handler.main.http_code_strategy'), 0, true, true, null]);
     }
 
     protected function getContainer(array $config = [], array $thirdPartyDefinitions = [])

--- a/Tests/DependencyInjection/MonologExtensionTest.php
+++ b/Tests/DependencyInjection/MonologExtensionTest.php
@@ -33,23 +33,15 @@ class MonologExtensionTest extends DependencyInjectionTest
 
         $handler = $container->getDefinition('monolog.handler.main');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
-        $this->assertDICConstructorArguments($handler, ['%kernel.logs_dir%/%kernel.environment%.log', \Monolog\Logger::DEBUG, true, null, false]
-        );
-        $this->assertDICDefinitionMethodCallAt(0, $handler, 'pushProcessor', [new Reference('monolog.processor.psr_log_message')]
-        );
+        $this->assertDICConstructorArguments($handler, ['%kernel.logs_dir%/%kernel.environment%.log', \Monolog\Logger::DEBUG, true, null, false]);
+        $this->assertDICDefinitionMethodCallAt(0, $handler, 'pushProcessor', [new Reference('monolog.processor.psr_log_message')]);
     }
 
     public function testLoadWithCustomValues()
     {
-        $container = $this->getContainer(
-            [
-                [
-                    'handlers' => [
+        $container = $this->getContainer([['handlers' => [
             'custom' => ['type' => 'stream', 'path' => '/tmp/symfony.log', 'bubble' => false, 'level' => 'ERROR', 'file_permission' => '0666', 'use_locking' => true]
-                    ]
-                ]
-            ]
-        );
+        ]]]);
         $this->assertTrue($container->hasDefinition('monolog.logger'));
         $this->assertTrue($container->hasDefinition('monolog.handler.custom'));
 
@@ -64,16 +56,10 @@ class MonologExtensionTest extends DependencyInjectionTest
 
     public function testLoadWithNestedHandler()
     {
-        $container = $this->getContainer(
-            [
-                [
-                    'handlers' => [
+        $container = $this->getContainer([['handlers' => [
             'custom' => ['type' => 'stream', 'path' => '/tmp/symfony.log', 'bubble' => false, 'level' => 'ERROR', 'file_permission' => '0666'],
             'nested' => ['type' => 'stream', 'path' => '/tmp/symfony.log', 'bubble' => false, 'level' => 'ERROR', 'file_permission' => '0666', 'nested' => true]
-                    ]
-                ]
-            ]
-        );
+        ]]]);
         $this->assertTrue($container->hasDefinition('monolog.logger'));
         $this->assertTrue($container->hasDefinition('monolog.handler.custom'));
         $this->assertTrue($container->hasDefinition('monolog.handler.nested'));
@@ -275,18 +261,10 @@ class MonologExtensionTest extends DependencyInjectionTest
             $this->assertContains('connection_string', $e->getMessage());
         }
 
-        $container = $this->getContainer(
-            [
-                [
-                    'handlers' => [
-                        'socket' => [
+        $container = $this->getContainer([['handlers' => ['socket' => [
             'type' => 'socket', 'timeout' => 1, 'persistent' => true,
             'connection_string' => 'localhost:50505', 'connection_timeout' => '0.6'
-                        ]
-                    ]
-                ]
-            ]
-        );
+        ]]]]);
         $this->assertTrue($container->hasDefinition('monolog.logger'));
         $this->assertTrue($container->hasDefinition('monolog.handler.socket'));
 
@@ -297,8 +275,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         $handler = $container->getDefinition('monolog.handler.socket');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\SocketHandler');
         $this->assertDICConstructorArguments($handler, ['localhost:50505', \Monolog\Logger::DEBUG, true]);
-        $this->assertDICDefinitionMethodCallAt(0, $handler, 'pushProcessor', [new Reference('monolog.processor.psr_log_message')]
-        );
+        $this->assertDICDefinitionMethodCallAt(0, $handler, 'pushProcessor', [new Reference('monolog.processor.psr_log_message')]);
         $this->assertDICDefinitionMethodCallAt(1, $handler, 'setTimeout', ['1']);
         $this->assertDICDefinitionMethodCallAt(2, $handler, 'setConnectionTimeout', ['0.6']);
         $this->assertDICDefinitionMethodCallAt(3, $handler, 'setPersistent', [true]);
@@ -318,17 +295,9 @@ class MonologExtensionTest extends DependencyInjectionTest
     {
         $dsn = 'http://43f6017361224d098402974103bfc53d:a6a0538fc2934ba2bed32e08741b2cd3@marca.python.live.cheggnet.com:9000/1';
 
-        $container = $this->getContainer(
-            [
-                [
-                    'handlers' => [
-                        'raven' => [
+        $container = $this->getContainer([['handlers' => ['raven' => [
             'type' => 'raven', 'dsn' => $dsn
-                        ]
-                    ]
-                ]
-            ]
-        );
+        ]]]]);
         $this->assertTrue($container->hasDefinition('monolog.logger'));
         $this->assertTrue($container->hasDefinition('monolog.handler.raven'));
 
@@ -344,17 +313,9 @@ class MonologExtensionTest extends DependencyInjectionTest
 
     public function testRavenHandlerWhenADSNAndAClientAreSpecified()
     {
-        $container = $this->getContainer(
-            [
-                [
-                    'handlers' => [
-                        'raven' => [
+        $container = $this->getContainer([['handlers' => ['raven' => [
             'type' => 'raven', 'dsn' => 'foobar', 'client_id' => 'raven.client'
-                        ]
-                    ]
-                ]
-            ]
-        );
+        ]]]]);
 
         $this->assertFalse($container->hasDefinition('raven.client'));
 
@@ -368,17 +329,9 @@ class MonologExtensionTest extends DependencyInjectionTest
 
     public function testRavenHandlerWhenAClientIsSpecified()
     {
-        $container = $this->getContainer(
-            [
-                [
-                    'handlers' => [
-                        'raven' => [
+        $container = $this->getContainer([['handlers' => ['raven' => [
             'type' => 'raven', 'client_id' => 'raven.client'
-                        ]
-                    ]
-                ]
-            ]
-        );
+        ]]]]);
 
         $this->assertFalse($container->hasDefinition('raven.client'));
 
@@ -404,17 +357,9 @@ class MonologExtensionTest extends DependencyInjectionTest
     {
         $dsn = 'http://43f6017361224d098402974103bfc53d:a6a0538fc2934ba2bed32e08741b2cd3@marca.python.live.cheggnet.com:9000/1';
 
-        $container = $this->getContainer(
-            [
-                [
-                    'handlers' => [
-                        'sentry' => [
+        $container = $this->getContainer([['handlers' => ['sentry' => [
             'type' => 'sentry', 'dsn' => $dsn
-                        ]
-                    ]
-                ]
-            ]
-        );
+        ]]]]);
         $this->assertTrue($container->hasDefinition('monolog.logger'));
         $this->assertTrue($container->hasDefinition('monolog.handler.sentry'));
 
@@ -491,33 +436,17 @@ class MonologExtensionTest extends DependencyInjectionTest
         }
 
         try {
-            $this->getContainer(
-                [
-                    [
-                        'handlers' => [
-                            'loggly' => [
+            $this->getContainer([['handlers' => ['loggly' => [
                 'type' => 'loggly', 'token' => $token, 'tags' => 'x, 1zone ,www.loggly.com,-us,apache$'
-                            ]
-                        ]
-                    ]
-                ]
-            );
+            ]]]]);
             $this->fail();
         } catch (InvalidConfigurationException $e) {
             $this->assertContains('-us, apache$', $e->getMessage());
         }
 
-        $container = $this->getContainer(
-            [
-                [
-                    'handlers' => [
-                        'loggly' => [
+        $container = $this->getContainer([['handlers' => ['loggly' => [
             'type' => 'loggly', 'token' => $token
-                        ]
-                    ]
-                ]
-            ]
-        );
+        ]]]]);
         $this->assertTrue($container->hasDefinition('monolog.logger'));
         $this->assertTrue($container->hasDefinition('monolog.handler.loggly'));
 
@@ -530,17 +459,9 @@ class MonologExtensionTest extends DependencyInjectionTest
         $this->assertDICDefinitionMethodCallAt(0, $handler, 'pushProcessor', [new Reference('monolog.processor.psr_log_message')]
         );
 
-        $container = $this->getContainer(
-            [
-                [
-                    'handlers' => [
-                        'loggly' => [
+        $container = $this->getContainer([['handlers' => ['loggly' => [
             'type' => 'loggly', 'token' => $token, 'tags' => [' ', 'foo', '', 'bar']
-                        ]
-                    ]
-                ]
-            ]
-        );
+        ]]]]);
         $handler = $container->getDefinition('monolog.handler.loggly');
         $this->assertDICDefinitionMethodCallAt(0, $handler, 'pushProcessor', [new Reference('monolog.processor.psr_log_message')]
         );
@@ -550,16 +471,10 @@ class MonologExtensionTest extends DependencyInjectionTest
     /** @group legacy */
     public function testFingersCrossedHandlerWhenExcluded404sAreSpecified()
     {
-        $container = $this->getContainer(
-            [
-                [
-                    'handlers' => [
+        $container = $this->getContainer([['handlers' => [
             'main' => ['type' => 'fingers_crossed', 'handler' => 'nested', 'excluded_404s' => ['^/foo', '^/bar']],
             'nested' => ['type' => 'stream', 'path' => '/tmp/symfony.log']
-                    ]
-                ]
-            ]
-        );
+        ]]]);
 
         $this->assertTrue($container->hasDefinition('monolog.logger'));
         $this->assertTrue($container->hasDefinition('monolog.handler.main'));
@@ -587,20 +502,14 @@ class MonologExtensionTest extends DependencyInjectionTest
             $this->markTestSkipped('Symfony Monolog 4.1+ is needed.');
         }
 
-        $container = $this->getContainer(
-            [
-                [
-                    'handlers' => [
+        $container = $this->getContainer([['handlers' => [
             'main' => [
                 'type' => 'fingers_crossed',
                 'handler' => 'nested',
                 'excluded_http_codes' => [403, 404, [405 => ['^/foo', '^/bar']]]
             ],
             'nested' => ['type' => 'stream', 'path' => '/tmp/symfony.log']
-                    ]
-                ]
-            ]
-        );
+        ]]]);
 
         $this->assertTrue($container->hasDefinition('monolog.logger'));
         $this->assertTrue($container->hasDefinition('monolog.handler.main'));


### PR DESCRIPTION
Since the minimum version was bumped last year to 5.6 we should leverage some of the niceties that we have.