### PR TITLE
Improve testing for a specific Symfony version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,29 +13,29 @@ env:
         - SYMFONY_PHPUNIT_DIR=.phpunit
 
 matrix:
-  fast_finish: true
-  include:
-    - php: 5.6
-      env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER=weak
-    # Test against Symfony LTS versions
-    - php: 5.6
-      env: SYMFONY_VERSION="3.4.*"
-    - php: 7.0
-    - php: 7.1
-      # There is a bug in PHPUnit 5.7
-      env: SYMFONY_PHPUNIT_VERSION=6.5
-    - php: 7.2
-    - php: 7.3
-    # Test against dev versions
-    - php: nightly
-      env: DEPENDENCIES=dev
-  allow_failures:
-    - env: DEPENDENCIES=dev
+    fast_finish: true
+    include:
+        - php: 5.6
+          env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER=weak
+        # Test against Symfony LTS versions
+        - php: 5.6
+          env: SYMFONY_REQUIRE="3.4.*"
+        - php: 7.0
+        - php: 7.1
+          # There is a bug in PHPUnit 5.7
+          env: SYMFONY_PHPUNIT_VERSION=6.5
+        - php: 7.2
+        - php: 7.3
+        # Test against dev versions
+        - php: nightly
+          env: DEPENDENCIES=dev
+    allow_failures:
+        - env: DEPENDENCIES=dev
 
 before_install:
     - composer self-update
     - if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
-    - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/symfony:"$SYMFONY_VERSION"; fi
+    - composer global require --no-progress --no-scripts --no-plugins symfony/flex dev-master
 
 install:
     - composer update $COMPOSER_FLAGS


### PR DESCRIPTION
Using global Symfony Flex helps limiting Symfony versions of the dependencies. Requiring `symfony/symfony` (currently used) means we cannot spot missed dependencies in this bundle for specific versions.

I've also fixed the indentation of the `matrix` section to match the 4 spaces in the rest of the file