### PR TITLE
Supporting v2 handlers and removing removed.

### DIFF
--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -957,13 +957,6 @@ class MonologExtension extends Extension
             }
         }
 
-        if (Logger::API === 1 && array_key_exists($handlerType, $v2HandlerTypesRemoved)) {
-            @trigger_error(
-                sprintf('"%s" is deprecated and will be removed in MonoLog v2.', $handlerType),
-                E_USER_DEPRECATED
-            );
-        }
-
         if (!isset($typeToClassMapping[$handlerType])) {
             if (Logger::API === 1 && array_key_exists($handlerType, $v2HandlerTypesAdded)) {
                 throw new InvalidArgumentException(

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -947,13 +947,21 @@ class MonologExtension extends Extension
         $v2HandlerTypesRemoved = [
             'hipchat',
             'raven',
+            'slackbot',
         ];
 
         if (Logger::API === 2) {
             $typeToClassMapping = array_merge($typeToClassMapping, $v2HandlerTypesAdded);
-            foreach($v2HandlerTypesRemoved as $handlerType) {
-                unset($typeToClassMapping[$handlerType]);
+            foreach($v2HandlerTypesRemoved as $v2HandlerTypeRemoved) {
+                unset($typeToClassMapping[$v2HandlerTypeRemoved]);
             }
+        }
+
+        if (Logger::API === 1 && array_key_exists($handlerType, $v2HandlerTypesRemoved)) {
+            @trigger_error(
+                sprintf('"%s" is deprecated and will be removed in MonoLog v2.', $handlerType),
+                E_USER_DEPRECATED
+            );
         }
 
         if (!isset($typeToClassMapping[$handlerType])) {

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -941,7 +941,15 @@ class MonologExtension extends Extension
         ];
 
         $v2HandlerTypesAdded = [
+            'elasticsearch' => 'Monolog\Handler\ElasticaHandler',
             'fallbackgroup' => 'Monolog\Handler\FallbackGroupHandler',
+            'logmatic' => 'Monolog\Handler\LogmaticHandler',
+            'noop' => 'Monolog\Handler\NoopHandler',
+            'overflow' => 'Monolog\Handler\OverflowHandler',
+            'process' => 'Monolog\Handler\ProcessHandler',
+            'sendgrid' => 'Monolog\Handler\SendGridHandler',
+            'sqs' => 'Monolog\Handler\SqsHandler',
+            'telegram' => 'Monolog\Handler\TelegramBotHandler',
         ];
 
         $v2HandlerTypesRemoved = [

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Bundle\MonologBundle\DependencyInjection;
 
-use InvalidArgumentException;
 use Monolog\Logger;
 use Monolog\Processor\ProcessorInterface;
 use Monolog\ResettableInterface;
@@ -859,7 +858,7 @@ class MonologExtension extends Extension
                 $nullWarning = ', if you meant to define a null handler in a yaml config, make sure you quote "null" so it does not get converted to a php null';
             }
 
-            throw new InvalidArgumentException(sprintf('Invalid handler type "%s" given for handler "%s"' . $nullWarning, $handler['type'], $name));
+            throw new \InvalidArgumentException(sprintf('Invalid handler type "%s" given for handler "%s"' . $nullWarning, $handler['type'], $name));
         }
 
         if (!empty($handler['nested']) && true === $handler['nested']) {
@@ -967,20 +966,14 @@ class MonologExtension extends Extension
 
         if (!isset($typeToClassMapping[$handlerType])) {
             if (Logger::API === 1 && array_key_exists($handlerType, $v2HandlerTypesAdded)) {
-                throw new InvalidArgumentException(
-                    sprintf('"%s" was added in MonoLog v2, please upgrade if you wish to use.', $handlerType)
-                );
+                throw new \InvalidArgumentException(sprintf('"%s" was added in Monolog v2, please upgrade if you wish to use it.', $handlerType));
             }
 
             if (Logger::API === 2 && array_key_exists($handlerType, $v2HandlerTypesRemoved)) {
-                throw new InvalidArgumentException(
-                    sprintf('"%s" was removed in MonoLog v2.', $handlerType)
-                );
+                throw new \InvalidArgumentException(sprintf('"%s" was removed in Monolog v2.', $handlerType));
             }
 
-            throw new InvalidArgumentException(
-                sprintf('There is no handler class defined for handler "%s".', $handlerType)
-            );
+            throw new \InvalidArgumentException(sprintf('There is no handler class defined for handler "%s".', $handlerType));
         }
 
         return $typeToClassMapping[$handlerType];

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -951,16 +951,21 @@ class MonologExtension extends Extension
 
         if (Logger::API === 2) {
             $typeToClassMapping = array_merge($typeToClassMapping, $v2HandlerTypesAdded);
-
             foreach($v2HandlerTypesRemoved as $handlerType) {
                 unset($typeToClassMapping[$handlerType]);
             }
         }
 
         if (!isset($typeToClassMapping[$handlerType])) {
-            if (array_key_exists($handlerType, $v2HandlerTypesAdded)) {
+            if (Logger::API === 1 && array_key_exists($handlerType, $v2HandlerTypesAdded)) {
                 throw new InvalidArgumentException(
-                    sprintf('"%s" was added in MonoLog 2, please upgrade if you wish to use.', $handlerType)
+                    sprintf('"%s" was added in MonoLog v2, please upgrade if you wish to use.', $handlerType)
+                );
+            }
+
+            if (Logger::API === 2 && array_key_exists($handlerType, $v2HandlerTypesRemoved)) {
+                throw new InvalidArgumentException(
+                    sprintf('"%s" was removed in MonoLog v2.', $handlerType)
                 );
             }
 

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -481,6 +481,7 @@ class MonologExtension extends Extension
                 $handler['bubble'],
             ]);
             break;
+
         case 'syslog':
             $definition->setArguments([
                 $handler['ident'],
@@ -939,27 +940,27 @@ class MonologExtension extends Extension
             'insightops' => 'Monolog\Handler\InsightOpsHandler',
         ];
 
-        $typeToClassMappingV2Added = [
+        $v2HandlerTypesAdded = [
             'fallbackgroup' => 'Monolog\Handler\FallbackGroupHandler',
         ];
 
-        $typeToClassMappingV2Removed = [
+        $v2HandlerTypesRemoved = [
             'hipchat',
             'raven',
         ];
 
         if (Logger::API === 2) {
-            $typeToClassMapping = array_merge($typeToClassMapping, $typeToClassMappingV2Added);
+            $typeToClassMapping = array_merge($typeToClassMapping, $v2HandlerTypesAdded);
 
-            foreach($typeToClassMappingV2Removed as $key) {
-                unset($typeToClassMapping[$key]);
+            foreach($v2HandlerTypesRemoved as $handlerType) {
+                unset($typeToClassMapping[$handlerType]);
             }
         }
 
         if (!isset($typeToClassMapping[$handlerType])) {
-            if (array_key_exists($handlerType, $typeToClassMappingV2Added)) {
+            if (array_key_exists($handlerType, $v2HandlerTypesAdded)) {
                 throw new InvalidArgumentException(
-                    sprintf('"%s" was added in MonoLog 2.', $handlerType)
+                    sprintf('"%s" was added in MonoLog 2, please upgrade if you wish to use.', $handlerType)
                 );
             }
 

--- a/Tests/DependencyInjection/MonologExtensionTest.php
+++ b/Tests/DependencyInjection/MonologExtensionTest.php
@@ -547,7 +547,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         }
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('"%s" was removed in MonoLog v2.', $handlerType));
+        $this->expectExceptionMessage(sprintf('"%s" was removed in Monolog v2.', $handlerType));
 
         $container = new ContainerBuilder();
         $loader = new MonologExtension();
@@ -578,7 +578,7 @@ class MonologExtensionTest extends DependencyInjectionTest
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            sprintf('"%s" was added in MonoLog v2, please upgrade if you wish to use.', $handlerType)
+            sprintf('"%s" was added in Monolog v2, please upgrade if you wish to use it.', $handlerType)
         );
 
         $container = new ContainerBuilder();

--- a/Tests/DependencyInjection/MonologExtensionTest.php
+++ b/Tests/DependencyInjection/MonologExtensionTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\MonologBundle\Tests\DependencyInjection;
 
+use Monolog\Logger;
 use Symfony\Bundle\MonologBundle\DependencyInjection\MonologExtension;
 use Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\LoggerChannelPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -530,6 +531,35 @@ class MonologExtensionTest extends DependencyInjectionTest
         $handler = $container->getDefinition('monolog.handler.main');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\FingersCrossedHandler');
         $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested'), new Reference('monolog.handler.main.http_code_strategy'), 0, true, true, null]);
+    }
+
+    /**
+     * @param string $handlerType
+     * @dataProvider v2RemovedDataProvider
+     */
+    public function testMonologV2RemovedOnV1($handlerType)
+    {
+        if (Logger::API === 2) {
+            $this->doesNotPerformAssertions();
+
+            return;
+        }
+
+        $this->expectException(InvalidConfigurationException::class);
+
+        $container = new ContainerBuilder();
+        $loader = new MonologExtension();
+
+        $loader->load([['handlers' => ['main' => ['type' => $handlerType]]]], $container);
+    }
+
+    public function v2RemovedDataProvider()
+    {
+        return [
+            ['hipchat'],
+            ['raven'],
+            ['slackbot'],
+        ];
     }
 
     protected function getContainer(array $config = [], array $thirdPartyDefinitions = [])


### PR DESCRIPTION
This would allow the wiring up of v2 handlers and preventing wiring of removed on V2 API.

Wanted to get feedback if this approach is suitable before I continue with adding tests to cover the validation aspect.

If you like the approach this is taking do you have any guidelines around testing against multiple versions of monolog? e.g. something like this https://github.com/g1a/composer-test-scenarios

Release notes: https://github.com/Seldaek/monolog/releases/tag/2.0.0