### PR TITLE
Handle composed monolog-bridge activation strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Register resettable processors (`ResettableInterface`) for autoconfiguration (tag: `kernel.reset`)
 * Drop support for Symfony 3.4
+* Handle composed monolog-bridge activation strategy
 
 ## 3.6.0 (2020-10-06)
 


### PR DESCRIPTION
Related to https://github.com/symfony/symfony/pull/35740

This PR instantiate the new HttpCodeActivationStrategy & NotFoundActivationStrategy with an inner strategy instead of an actionLevel

closes #369