### PR TITLE
Add container.preload tag on all handlers

### DIFF
--- a/DependencyInjection/Compiler/DebugHandlerPass.php
+++ b/DependencyInjection/Compiler/DebugHandlerPass.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\MonologBundle\DependencyInjection\Compiler;
 
+use Symfony\Component\DependencyInjection\Dumper\Preloader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -47,6 +48,11 @@ class DebugHandlerPass implements CompilerPassInterface
         }
 
         $debugHandler = new Definition('Symfony\Bridge\Monolog\Handler\DebugHandler', [Logger::DEBUG, true]);
+
+        if (class_exists(Preloader::class)) {
+            $debugHandler->addTag('container.preload');
+        }
+
         $container->setDefinition('monolog.handler.debug', $debugHandler);
 
         foreach ($this->channelPass->getChannels() as $channel) {

--- a/DependencyInjection/Compiler/FixEmptyLoggerPass.php
+++ b/DependencyInjection/Compiler/FixEmptyLoggerPass.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\MonologBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Dumper\Preloader;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -40,7 +41,11 @@ class FixEmptyLoggerPass implements CompilerPassInterface
 
     public function process(ContainerBuilder $container)
     {
-        $container->register('monolog.handler.null_internal', 'Monolog\Handler\NullHandler');
+        $nullHandler = $container->register('monolog.handler.null_internal', 'Monolog\Handler\NullHandler');
+        if (class_exists(Preloader::class)) {
+            $nullHandler->addTag('container.preload');
+        }
+
         foreach ($this->channelPass->getChannels() as $channel) {
             $def = $container->getDefinition($channel === 'app' ? 'monolog.logger' : 'monolog.logger.'.$channel);
             foreach ($def->getMethodCalls() as $method) {

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -23,6 +23,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Argument\BoundArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Dumper\Preloader;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -134,6 +135,11 @@ class MonologExtension extends Extension
                 $handlerAutoconfiguration->setBindings($handlerAutoconfiguration->getBindings() + [
                     HttpClientInterface::class => new BoundArgument(new Reference('monolog.http_client'), false),
                 ]);
+            }
+
+            if (class_exists(Preloader::class)) {
+                $container->registerForAutoconfiguration(HandlerInterface::class)
+                    ->addTag('container.preload');
             }
         }
     }
@@ -880,6 +886,10 @@ class MonologExtension extends Extension
 
         if (!in_array($handlerId, $this->nestedHandlers) && is_subclass_of($handlerClass, ResettableInterface::class)) {
             $definition->addTag('kernel.reset', ['method' => 'reset']);
+        }
+
+        if (class_exists(Preloader::class)) {
+            $definition->addTag('container.preload');
         }
 
         $container->setDefinition($handlerId, $definition);


### PR DESCRIPTION
The `ConsoleHandler` is an event subscriber and therefore gets the `container.no_preload` tag automatically. However, we want to preload this class because it is in the hot path. So we have to add the `container.preload` tag to it (see https://github.com/symfony/symfony/pull/36742).

Instead of just adding the tag for this handler, it's better to add it for all (automatically) because all handlers are always pushed to a logger.
