### PR TITLE
Add "name" option to Raven_Client

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -202,6 +202,7 @@ use Monolog\Logger;
  *   - [bubble]: bool, defaults to true
  *   - [auto_log_stacks]: bool, defaults to false
  *   - [environment]: string, default to null (no env specified)
+ *   - [name]: string, hostname, default to null (detect hostname)
  *
  * - newrelic:
  *   - [level]: level name or int value, defaults to DEBUG
@@ -634,6 +635,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('auto_log_stacks')->defaultFalse()->end() // raven_handler
                             ->scalarNode('release')->defaultNull()->end() // raven_handler, sentry_handler
                             ->scalarNode('environment')->defaultNull()->end() // raven_handler, sentry_handler
+                            ->scalarNode('name')->defaultNull()->end() // raven_handler, sentry_handler
                             ->scalarNode('message_type')->defaultValue(0)->end() // error_log
                             ->arrayNode('tags') // loggly
                                 ->beforeNormalization()

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -738,7 +738,8 @@ class MonologExtension extends Extension
                     $handler['dsn'],
                     [
                         'auto_log_stacks' => $handler['auto_log_stacks'],
-                        'environment' => $handler['environment']
+                        'environment' => $handler['environment'],
+                        'name' => $handler['name'],
                     ]
                 ]);
                 $client->setPublic(false);


### PR DESCRIPTION
The `Raven_Client` accepts an option **name** to specify the hostname.

This PR allows to configure it.