### PR TITLE
Adds ForwardCompatTestTrait and fixes related Test

### DIFF
--- a/Tests/DependencyInjection/Compiler/AddSwiftMailerTransportPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddSwiftMailerTransportPassTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\AddSwiftMailerTransportPass;
+use Symfony\Bundle\MonologBundle\Tests\ForwardCompatTestTrait;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -20,13 +21,15 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class AddSwiftMailerTransportPassTest extends TestCase
 {
+    use ForwardCompatTestTrait;
+
     private $compilerPass;
 
     private $container;
 
     private $definition;
 
-    protected function setUp()
+    protected function doSetUp()
     {
         $this->compilerPass = new AddSwiftMailerTransportPass();
         $this->definition = $this->getMockBuilder('\Symfony\Component\DependencyInjection\Definition')->getMock();

--- a/Tests/ForwardCompatTestTrait.php
+++ b/Tests/ForwardCompatTestTrait.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MonologBundle\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+// Auto-adapt to PHPUnit 8 that added a `void` return-type to the setUp/tearDown methods
+
+if (method_exists(\ReflectionMethod::class, 'hasReturnType') && (new \ReflectionMethod(TestCase::class, 'tearDown'))->hasReturnType()) {
+    eval('
+    namespace Symfony\Bundle\MonologBundle\Tests;
+
+    /**
+     * @internal
+     */
+    trait ForwardCompatTestTrait
+    {
+        private function doSetUp(): void
+        {
+        }
+
+        private function doTearDown(): void
+        {
+        }
+
+        protected function setUp(): void
+        {
+            $this->doSetUp();
+        }
+
+        protected function tearDown(): void
+        {
+            $this->doTearDown();
+        }
+    }
+');
+} else {
+    /**
+     * @internal
+     */
+    trait ForwardCompatTestTrait
+    {
+        /**
+         * @return void
+         */
+        private function doSetUp()
+        {
+        }
+
+        /**
+         * @return void
+         */
+        private function doTearDown()
+        {
+        }
+
+        /**
+         * @return void
+         */
+        protected function setUp()
+        {
+            $this->doSetUp();
+        }
+
+        /**
+         * @return void
+         */
+        protected function tearDown()
+        {
+            $this->doTearDown();
+        }
+    }
+}


### PR DESCRIPTION
Fixes PHP Fatal error in newer PHP versions:

> PHP Fatal error:  Declaration of  Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Compiler\AddSwiftMailerTransportPassTest::setUp() must be compatible with PHPUnit\Framework\TestCase::setUp(): void in /Volumes/Projects/symfony/monolog-bundle/Tests/DependencyInjection/Compiler/AddSwiftMailerTransportPassTest.php on line 29

I copied the ForwardCompatTestTrait from Symfony\Validator: https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Validator/Test/ForwardCompatTestTrait.php