### PR TITLE
Fix tests for php7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,17 +24,32 @@ matrix:
     - php: 7.1
       # There is a bug in PHPUnit 5.7
       env: SYMFONY_PHPUNIT_VERSION=6.5
+    # Test against seldaek/monolog 1.x
     - php: 7.2
+      env: MONOLOG_VERSION=1.*
     - php: 7.3
+      env: MONOLOG_VERSION=1.*
+    - php: 7.4
+      env: MONOLOG_VERSION=1.*
+    # Test against seldaek/monolog 2.x
+    - php: 7.2
+      env: MONOLOG_VERSION=2.*
+    - php: 7.3
+      env: MONOLOG_VERSION=2.*
+    - php: 7.4
+      env: MONOLOG_VERSION=2.*
     # Test against dev versions
     - php: nightly
-      env: DEPENDENCIES=dev
+      env: DEPENDENCIES=dev MONOLOG_VERSION=1.*
+    - php: nightly
+      env: DEPENDENCIES=dev MONOLOG_VERSION=2.*
   allow_failures:
-    - env: DEPENDENCIES=dev
+    - php: nightly
 
 before_install:
     - composer self-update
     - if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
+    - if [ "$MONOLOG_VERSION" != "" ]; then composer require --dev --no-update monolog/monolog:"$MONOLOG_VERSION"; fi;
     - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/symfony:"$SYMFONY_VERSION"; fi
 
 install:

--- a/Tests/DependencyInjection/Compiler/AddSwiftMailerTransportPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddSwiftMailerTransportPassTest.php
@@ -26,7 +26,10 @@ class AddSwiftMailerTransportPassTest extends TestCase
 
     private $definition;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function doSetUp()
     {
         $this->compilerPass = new AddSwiftMailerTransportPass();
         $this->definition = $this->getMockBuilder('\Symfony\Component\DependencyInjection\Definition')->getMock();

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\MonologBundle\Tests\DependencyInjection;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MonologBundle\DependencyInjection\Configuration;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -143,9 +144,6 @@ class ConfigurationTest extends TestCase
         $this->assertEquals('D', $config['handlers']['bar']['channels']['elements'][1]);
     }
 
-    /**
-     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
     public function testInvalidArrays()
     {
         $configs = [
@@ -160,12 +158,11 @@ class ConfigurationTest extends TestCase
             ]
         ];
 
+        $this->expectException(InvalidConfigurationException::class);
+
         $config = $this->process($configs);
     }
 
-    /**
-     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
     public function testMergingInvalidChannels()
     {
         $configs = [
@@ -186,6 +183,8 @@ class ConfigurationTest extends TestCase
                 ]
             ]
         ];
+
+        $this->expectException(InvalidConfigurationException::class);
 
         $config = $this->process($configs);
     }

--- a/Tests/DependencyInjection/FixtureMonologExtensionTest.php
+++ b/Tests/DependencyInjection/FixtureMonologExtensionTest.php
@@ -202,7 +202,7 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
 
         $methodCalls = $logger->getMethodCalls();
 
-        $this->assertContains(['pushProcessor', [new Reference('monolog.processor.psr_log_message')]], $methodCalls, 'The PSR-3 processor should be enabled', false, false);
+        $this->assertContainsEquals(['pushProcessor', [new Reference('monolog.processor.psr_log_message')]], $methodCalls, 'The PSR-3 processor should be enabled');
     }
 
     public function testPsr3MessageProcessingDisabled()
@@ -213,7 +213,7 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
 
         $methodCalls = $logger->getMethodCalls();
 
-        $this->assertNotContains(['pushProcessor', [new Reference('monolog.processor.psr_log_message')]], $methodCalls, 'The PSR-3 processor should not be enabled', false, false);
+        $this->assertNotContainsEquals(['pushProcessor', [new Reference('monolog.processor.psr_log_message')]], $methodCalls, 'The PSR-3 processor should not be enabled');
     }
 
     public function testNativeMailer()

--- a/Tests/DependencyInjection/Fixtures/yml/multiple_handlers.yml
+++ b/Tests/DependencyInjection/Fixtures/yml/multiple_handlers.yml
@@ -5,7 +5,7 @@ monolog:
             path: /tmp/symfony.log
             bubble: false
             level: ERROR
-            file_permission: 0666
+            file_permission: 438 # decimal representation of 0666 octal
         main:
             type: fingers_crossed
             action_level: ERROR

--- a/Tests/DependencyInjection/XmlMonologExtensionTest.php
+++ b/Tests/DependencyInjection/XmlMonologExtensionTest.php
@@ -13,12 +13,15 @@ namespace Symfony\Bundle\MonologBundle\Tests\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 class XmlMonologExtensionTest extends FixtureMonologExtensionTest
 {
     protected function loadFixture(ContainerBuilder $container, $fixture)
     {
+        $container->setDefinition('mailer', new Definition('Swiftmailer'));
+
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/Fixtures/xml'));
         $loader->load($fixture.'.xml');
     }

--- a/Tests/DependencyInjection/YamlMonologExtensionTest.php
+++ b/Tests/DependencyInjection/YamlMonologExtensionTest.php
@@ -13,12 +13,15 @@ namespace Symfony\Bundle\MonologBundle\Tests\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
 class YamlMonologExtensionTest extends FixtureMonologExtensionTest
 {
     protected function loadFixture(ContainerBuilder $container, $fixture)
     {
+        $container->setDefinition('mailer', new Definition('Swiftmailer'));
+
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/Fixtures/yml'));
         $loader->load($fixture.'.yml');
     }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "symfony/yaml": "~3.4 || ~4.0 || ^5.0",
         "symfony/console": "~3.4 || ~4.0 || ^5.0",
-        "symfony/phpunit-bridge": "^3.4.19 || ^4.0 || ^5.0"
+        "symfony/phpunit-bridge": "^4.4 || ^5.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bundle\\MonologBundle\\": "" },


### PR DESCRIPTION
Combines previous PRs #358 and #359 together with fixes for failing tests on Travis.

 * Updates travis test matrix:
   * Adds PHP 7.4 to test matrix
   * Expands test matrix for PHP 7.2+ to check against both monolog 1 & 2
 * Fixes PHPUnit deprecations:
   * Fixes invalid method signature for `setUp()`
   * Replaces deprecated assertions (assertContains, assertNotContains)
   * Replaces deprecated expectedExceptions annotations
 * Fixes missing service definitions in container configurations

Closes #351 as well