### PR TITLE
Add Datadog monolog integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.7.0 (xxxx-xx-xx)
 
+* Add support for `datadog` handler
 * Use `ActivationStrategy` instead of `actionLevel` when available 
 * Register resettable processors (`ResettableInterface`) for autoconfiguration (tag: `kernel.reset`)
 * Drop support for Symfony 3.4

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -326,6 +326,18 @@ use Monolog\Logger;
  *   - [level]: level name or int value, defaults to DEBUG
  *   - [bubble]: bool, defaults to true
  *
+ * - datadog:
+ *   - token: Api Key supplied by Datadog
+ *   - region: Region where Datadog data are hosted. Could be 'us' or 'eu'. Defaults to 'us'
+ *   - [app_name]: Application name used as the "source" Datadog attribute inside the DatadogFormatter. Defaults to null
+ *   - [system_name]: The system/machine name, used as the "host" Datadog attribute inside the DatadogFormatter. Defaults to null
+ *   - [environment]: The environment, used as the "env" Datadog attribute. Defaults to null
+ *   - [source]: This corresponds to the integration name: the technology from which the log originated. Must be one of the following list: https://app.datadoghq.eu/logs/pipelines/pipeline/library. If not set, the formatter uses 'php'.
+ *   - [logger_name]: Name of the logger, used as the "logger.name" Datadog attribute inside the DatadogFormatter. Defaults to 'monolog'
+ *   - [use_ssl]: whether or not SSL encryption should be used, defaults to true
+ *   - [level]: level name or int value, defaults to DEBUG
+ *   - [bubble]: bool, defaults to true
+ *
  * - server_log:
  *   - host: server log host. ex: 127.0.0.1:9911
  *   - [level]: level name or int value, defaults to DEBUG
@@ -381,7 +393,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('priority')->defaultValue(0)->end()
                             ->scalarNode('level')->defaultValue('DEBUG')->end()
                             ->booleanNode('bubble')->defaultTrue()->end()
-                            ->scalarNode('app_name')->defaultNull()->end()
+                            ->scalarNode('app_name')->defaultNull()->end() // newrelic & datadog
                             ->booleanNode('include_stacktraces')->defaultFalse()->end()
                             ->booleanNode('process_psr_3_messages')->defaultNull()->end()
                             ->scalarNode('path')->defaultValue('%kernel.logs_dir%/%kernel.environment%.log')->end() // stream and rotating
@@ -472,10 +484,12 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('team')->end() // slackbot
                             ->scalarNode('notify')->defaultFalse()->end() // hipchat
                             ->scalarNode('nickname')->defaultValue('Monolog')->end() // hipchat
-                            ->scalarNode('token')->end() // pushover & hipchat & loggly & logentries & flowdock & rollbar & slack & slackbot & insightops
-                            ->scalarNode('region')->end() // insightops
-                            ->scalarNode('source')->end() // flowdock
-                            ->booleanNode('use_ssl')->defaultTrue()->end() // logentries & hipchat & insightops
+                            ->scalarNode('token')->end() // pushover & hipchat & loggly & logentries & flowdock & rollbar & slack & slackbot & insightops & datadog
+                            ->scalarNode('region')->end() // insightops & datadog
+                            ->scalarNode('source')->end() // flowdock & datadog
+                            ->scalarNode('system_name')->defaultNull()->end() // datadog
+                            ->scalarNode('logger_name')->defaultValue('monolog')->end() // datadog
+                            ->booleanNode('use_ssl')->defaultTrue()->end() // logentries & hipchat & insightops & datadog
                             ->variableNode('user') // pushover
                                 ->validate()
                                     ->ifTrue(function ($v) {
@@ -643,7 +657,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('client_id')->defaultNull()->end() // raven_handler, sentry_handler
                             ->scalarNode('auto_log_stacks')->defaultFalse()->end() // raven_handler
                             ->scalarNode('release')->defaultNull()->end() // raven_handler, sentry_handler
-                            ->scalarNode('environment')->defaultNull()->end() // raven_handler, sentry_handler
+                            ->scalarNode('environment')->defaultNull()->end() // raven_handler, sentry_handler, datadog
                             ->scalarNode('message_type')->defaultValue(0)->end() // error_log
                             ->arrayNode('tags') // loggly
                                 ->beforeNormalization()
@@ -922,6 +936,10 @@ class Configuration implements ConfigurationInterface
                         ->validate()
                             ->ifTrue(function ($v) { return 'insightops' === $v['type'] && empty($v['token']); })
                             ->thenInvalid('The token has to be specified to use a InsightOpsHandler')
+                        ->end()
+                        ->validate()
+                            ->ifTrue(function ($v) { return 'datadog' === $v['type'] && empty($v['token']); })
+                            ->thenInvalid('The token (Api Key) has to be specified to use a DatadogHandler')
                         ->end()
                         ->validate()
                             ->ifTrue(function ($v) { return 'flowdock' === $v['type'] && empty($v['token']); })

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -884,6 +884,30 @@ class MonologExtension extends Extension
                 $handler['bubble'],
             ]);
             break;
+        case 'datadog':
+            $definition->setArguments([
+                $handler['token'],
+                $handler['region'] ? $handler['region'] : 'us',
+                $handler['use_ssl'],
+                $handler['level'],
+                $handler['bubble'],
+            ]);
+
+            if (empty($handler['formatter'])) {
+                $formatter = new Definition('Monolog\Formatter\DatadogFormatter', [
+                    $handler['app_name'],
+                    $handler['system_name'],
+                    $handler['environment'],
+                    isset($handler['source']) ? $handler['source'] : 'php',
+                    $handler['logger_name'],
+                ]);
+                $formatterId = 'monolog.datadog.formatter';
+                $formatter->setPublic(false);
+                $container->setDefinition($formatterId, $formatter);
+
+                $definition->addMethodCall('setFormatter', [new Reference($formatterId)]);
+            }
+            break;
 
         // Handlers using the constructor of AbstractHandler without adding their own arguments
         case 'browser_console':
@@ -983,6 +1007,7 @@ class MonologExtension extends Extension
             'redis' => 'Monolog\Handler\RedisHandler',
             'predis' => 'Monolog\Handler\RedisHandler',
             'insightops' => 'Monolog\Handler\InsightOpsHandler',
+            'datadog' => 'Monolog\Handler\DatadogHandler',
         ];
 
         $v2HandlerTypesAdded = [


### PR DESCRIPTION
This PR adds the support of Datadog to the list of supported integrations.

⚠️ We need to wait for this related `monolog` PR to be merged first: https://github.com/Seldaek/monolog/pull/1504 ⚠️

The configuration looks like this (example):

```yml
monolog:
    handlers:
        datadog:
            type: datadog
            region: eu
            token: xxxxxxxxxxxxxxxxxxxxx
            app_name: foo
```

Here's what is outputed in the datadog log section: 

### Summary:
![Log_Explorer___Datadog](https://user-images.githubusercontent.com/346010/95358949-e34f3600-08c9-11eb-8289-6680d3e03fa1.png)

### Log details: 
![Log_Explorer___Datadog](https://user-images.githubusercontent.com/346010/95359174-23161d80-08ca-11eb-802f-56ebf9af4a53.png)

### Exception:
![Log_Explorer___Datadog](https://user-images.githubusercontent.com/346010/95359102-0da0f380-08ca-11eb-8c9c-a49c027cfb9b.png)
