### PR TITLE
Autoconfigure resettable processors with the kernel.reset tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.6.1 (xxxx-xx-xx)
+
+* Register resettable processors (`ResettableInterface`) for autoconfiguration (tag: `kernel.reset`)
+
 ## 3.6.0 (2020-10-06)
 
 * Added support for Symfony Mailer

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -150,6 +150,10 @@ class MonologExtension extends Extension
                 $container->registerForAutoconfiguration(WebProcessor::class)
                     ->addTag('monolog.processor');
             }
+            if (interface_exists(ResettableInterface::class)) {
+                $container->registerForAutoconfiguration(ResettableInterface::class)
+                    ->addTag('kernel.reset', ['method' => 'reset']);
+            }
             $container->registerForAutoconfiguration(TokenProcessor::class)
                 ->addTag('monolog.processor');
             if (interface_exists(HttpClientInterface::class)) {


### PR DESCRIPTION
fixed #361 for more details.

### TODO

- [x] add the `kernel.reset` tag to processors implementing the `ResettableInterface`
- [x] add a test in the `MonologExtensionTest` class

