### PR TITLE
Fix infinite loop in LogLevel detection

### DIFF
--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -62,7 +62,7 @@ class MonologExtension extends Extension
             throw new \InvalidArgumentException(sprintf('Could not match "%s" to a log level.', $level));
         }
 
-        if ($logLevel !== '') {
+        if ($logLevel !== '' && $logLevel !== $level) {
             return $this->levelToMonologConst($logLevel, $container);
         }
 

--- a/Tests/DependencyInjection/MonologExtensionTest.php
+++ b/Tests/DependencyInjection/MonologExtensionTest.php
@@ -60,6 +60,15 @@ class MonologExtensionTest extends DependencyInjectionTest
         $this->assertDICConstructorArguments($handler, ['/tmp/symfony.log', \Monolog\Logger::ERROR, false, 0666, true]);
     }
 
+    public function testLoadWithUnknownLevel()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Could not match "warn" to a log level.');
+        $container = $this->getContainer([['handlers' => [
+            'custom' => ['type' => 'stream', 'path' => '/tmp/symfony.log', 'bubble' => false, 'level' => 'warn', 'file_permission' => '0666', 'use_locking' => true]
+        ]]]);
+    }
+
     public function testLoadWithNestedHandler()
     {
         $container = $this->getContainer([['handlers' => [


### PR DESCRIPTION
While converting the logLevel into the right const value, calling `$container->resolveEnvPlaceholders($level, true);` does not always throw an exception and returns the value provided in INPUT, leading to an infinite loop

This PR fixes  https://github.com/symfony/monolog-bundle/issues/367#issuecomment-723988352 BUT is not related to the issue https://github.com/symfony/monolog-bundle/issues/367#issue-718712384
