### PR TITLE
Fix travis xdebug coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
 env:
     global:
         - SYMFONY_PHPUNIT_DIR=.phpunit
+        - XDEBUG_MODE=coverage
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
In order to fix failing PHP 7.3 tests:

`PHP Fatal error:  Uncaught SebastianBergmann\CodeCoverage\RuntimeException: XDEBUG_MODE=coverage or xdebug.mode=coverage has to be set in /home/travis/build/symfony/monolog-bundle/.phpunit/phpunit-8.3-0/vendor/phpunit/php-code-coverage/src/Driver/Xdebug.php:50`

Travis builds are failing under the new version of xdebug, you can fix that with setting XDEBUG_MODE to "coverage" in the config. See https://travis-ci.community/t/xdebug-3-is-installed-by-default-breaking-builds/10748