### PR TITLE
Typo in console formatter option name

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -38,7 +38,7 @@ use Monolog\Logger;
  *   - [verbosity_levels]: level => verbosity configuration
  *   - [level]: level name or int value, defaults to DEBUG
  *   - [bubble]: bool, defaults to true
- *   - [console_formater_options]: array
+ *   - [console_formatter_options]: array
  *
  * - firephp:
  *   - [level]: level name or int value, defaults to DEBUG
@@ -657,12 +657,19 @@ class Configuration implements ConfigurationInterface
                             ->end()
                              // console
                             ->variableNode('console_formater_options')
-                                ->defaultValue([])
+                                ->setDeprecated('"%path%.%node%" is deprecated, use "%path%.console_formatter_options" instead.')
                                 ->validate()
                                     ->ifTrue(function ($v) {
                                         return !is_array($v);
                                     })
-                                    ->thenInvalid('console_formater_options must an array.')
+                                    ->thenInvalid('The console_formater_options must be an array.')
+                                ->end()
+                            ->end()
+                            ->variableNode('console_formatter_options')
+                                ->defaultValue([])
+                                ->validate()
+                                    ->ifTrue(static function ($v) { return !is_array($v); })
+                                    ->thenInvalid('The console_formatter_options must be an array.')
                                 ->end()
                             ->end()
                             ->arrayNode('verbosity_levels') // console
@@ -782,6 +789,18 @@ class Configuration implements ConfigurationInterface
                             ->end()
                             ->scalarNode('formatter')->end()
                             ->booleanNode('nested')->defaultFalse()->end()
+                        ->end()
+                        ->beforeNormalization()
+                            ->always(static function ($v) {
+                                if (empty($v['console_formatter_options']) && !empty($v['console_formater_options'])) {
+                                    $v['console_formatter_options'] = $v['console_formater_options'];
+                                }
+
+                                return $v;
+                            })
+                        ->end()
+                        ->validate()
+                            ->always(static function ($v) { unset($v['console_formater_options']); return $v; })
                         ->end()
                         ->validate()
                             ->ifTrue(function ($v) { return 'service' === $v['type'] && !empty($v['formatter']); })

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -215,7 +215,7 @@ class MonologExtension extends Extension
                 null,
                 $handler['bubble'],
                 isset($handler['verbosity_levels']) ? $handler['verbosity_levels'] : [],
-                $handler['console_formater_options']
+                $handler['console_formatter_options']
             ]);
             $definition->addTag('kernel.event_subscriber');
             break;

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -361,6 +361,7 @@ class ConfigurationTest extends TestCase
 
         $this->assertTrue($config['handlers']['foobar']['nested']);
     }
+
     public function testWithRedisHandler()
     {
         $configs = [
@@ -404,6 +405,88 @@ class ConfigurationTest extends TestCase
 
         $this->assertEquals('127.0.1.1', $config['handlers']['redis']['redis']['host']);
         $this->assertEquals('monolog_redis_test', $config['handlers']['redis']['redis']['key_name']);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testConsoleFormatterOptionsRename()
+    {
+        $configs = [
+            [
+                'handlers' => [
+                    'old' => [
+                        'type' => 'console',
+                        'console_formater_options' => ['foo' => 'foo'],
+                    ],
+                    'old2' => [
+                        'type' => 'console',
+                        'console_formater_options' => ['foo' => 'foo'],
+                    ],
+                    'new' => [
+                        'type' => 'console',
+                        'console_formatter_options' => ['bar' => 'bar'],
+                    ],
+                    'new2' => [
+                        'type' => 'console',
+                        'console_formatter_options' => ['bar' => 'bar'],
+                    ],
+                    'both' => [
+                        'type' => 'console',
+                        'console_formater_options' => ['foo' => 'foo'],
+                        'console_formatter_options' => ['bar' => 'bar'],
+                    ],
+                    'both2' => [
+                        'type' => 'console',
+                        'console_formater_options' => ['foo' => 'foo'],
+                        'console_formatter_options' => ['bar' => 'bar'],
+                    ],
+                ],
+            ],
+            [
+                'handlers' => [
+                    'old2' => [
+                        'type' => 'console',
+                        'console_formater_options' => ['baz' => 'baz'],
+                    ],
+                    'new2' => [
+                        'type' => 'console',
+                        'console_formatter_options' => ['qux' => 'qux'],
+                    ],
+                    'both2' => [
+                        'type' => 'console',
+                        'console_formater_options' => ['baz' => 'baz'],
+                        'console_formatter_options' => ['qux' => 'qux'],
+                    ],
+                ],
+            ],
+        ];
+
+        $config = $this->process($configs);
+
+        $this->assertArrayHasKey('console_formatter_options', $config['handlers']['old']);
+        $this->assertSame(['foo' => 'foo'], $config['handlers']['old']['console_formatter_options']);
+        $this->assertArrayNotHasKey('console_formater_options', $config['handlers']['old']);
+
+        $this->assertArrayHasKey('console_formatter_options', $config['handlers']['new']);
+        $this->assertSame(['bar' => 'bar'], $config['handlers']['new']['console_formatter_options']);
+        $this->assertArrayNotHasKey('console_formater_options', $config['handlers']['new']);
+
+        $this->assertArrayHasKey('console_formatter_options', $config['handlers']['both']);
+        $this->assertSame(['bar' => 'bar'], $config['handlers']['both']['console_formatter_options']);
+        $this->assertArrayNotHasKey('console_formater_options', $config['handlers']['both']);
+
+        $this->assertArrayHasKey('console_formatter_options', $config['handlers']['old2']);
+        $this->assertSame(['baz' => 'baz'], $config['handlers']['old2']['console_formatter_options']);
+        $this->assertArrayNotHasKey('console_formater_options', $config['handlers']['old2']);
+
+        $this->assertArrayHasKey('console_formatter_options', $config['handlers']['new2']);
+        $this->assertSame(['qux' => 'qux'], $config['handlers']['new2']['console_formatter_options']);
+        $this->assertArrayNotHasKey('console_formater_options', $config['handlers']['new2']);
+
+        $this->assertArrayHasKey('console_formatter_options', $config['handlers']['both2']);
+        $this->assertSame(['qux' => 'qux'], $config['handlers']['both2']['console_formatter_options']);
+        $this->assertArrayNotHasKey('console_formater_options', $config['handlers']['both2']);
     }
 
     /**


### PR DESCRIPTION
The `console_formater_options` has a typo. This PR deprecates the option and replaces it with `console_formatter_options` while maintaining backwards compatibility.