### PR TITLE
Issue 335

### DIFF
--- a/DependencyInjection/Compiler/AddProcessorsPass.php
+++ b/DependencyInjection/Compiler/AddProcessorsPass.php
@@ -11,8 +11,9 @@
 
 namespace Symfony\Bundle\MonologBundle\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Monolog\Handler\ProcessableHandlerInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -46,13 +47,15 @@ class AddProcessorsPass implements CompilerPassInterface
                     $definition = $container->getDefinition('monolog.logger_prototype');
                 }
 
-                if (!empty($tag['method'])) {
-                    $processor = [new Reference($id), $tag['method']];
-                } else {
-                    // If no method is defined, fallback to use __invoke
-                    $processor = new Reference($id);
+                if (is_a($definition->getClass(), ProcessableHandlerInterface::class, true)) {
+                    if (!empty($tag['method'])) {
+                        $processor = [new Reference($id), $tag['method']];
+                    } else {
+                        // If no method is defined, fallback to use __invoke
+                        $processor = new Reference($id);
+                    }
+                    $definition->addMethodCall('pushProcessor', [$processor]);
                 }
-                $definition->addMethodCall('pushProcessor', [$processor]);
             }
         }
     }

--- a/DependencyInjection/Compiler/AddProcessorsPass.php
+++ b/DependencyInjection/Compiler/AddProcessorsPass.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\MonologBundle\DependencyInjection\Compiler;
 
 use Monolog\Handler\ProcessableHandlerInterface;
+use Monolog\Logger;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -47,7 +48,7 @@ class AddProcessorsPass implements CompilerPassInterface
                     $definition = $container->getDefinition('monolog.logger_prototype');
                 }
 
-                if (is_a($definition->getClass(), ProcessableHandlerInterface::class, true)) {
+                if (1 === Logger::API || is_a($definition->getClass(), ProcessableHandlerInterface::class, true)) {
                     if (!empty($tag['method'])) {
                         $processor = [new Reference($id), $tag['method']];
                     } else {

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -189,7 +189,12 @@ class MonologExtension extends Extension
             $handler['process_psr_3_messages'] = !isset($handler['handler']) && !$handler['members'];
         }
 
-        if ($handler['process_psr_3_messages'] && is_a($handlerClass, ProcessableHandlerInterface::class, true)) {
+        if ($handler['process_psr_3_messages'] 
+            && (
+                1 === Logger::API
+                || is_a($handlerClass, ProcessableHandlerInterface::class, true)
+            )
+        ) {
             $processorId = 'monolog.processor.psr_log_message';
             if (!$container->hasDefinition($processorId)) {
                 $processor = new Definition('Monolog\\Processor\\PsrLogMessageProcessor');

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\MonologBundle\DependencyInjection;
 use Monolog\Logger;
 use Monolog\Processor\ProcessorInterface;
 use Monolog\Handler\HandlerInterface;
+use Monolog\Handler\ProcessableHandlerInterface;
 use Monolog\ResettableInterface;
 use Symfony\Bridge\Monolog\Handler\FingersCrossed\HttpCodeActivationStrategy;
 use Symfony\Bridge\Monolog\Processor\TokenProcessor;
@@ -188,7 +189,7 @@ class MonologExtension extends Extension
             $handler['process_psr_3_messages'] = !isset($handler['handler']) && !$handler['members'];
         }
 
-        if ($handler['process_psr_3_messages']) {
+        if ($handler['process_psr_3_messages'] && is_a($handlerClass, ProcessableHandlerInterface::class, true)) {
             $processorId = 'monolog.processor.psr_log_message';
             if (!$container->hasDefinition($processorId)) {
                 $processor = new Definition('Monolog\\Processor\\PsrLogMessageProcessor');

--- a/Tests/DependencyInjection/Compiler/AddProcessorsPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddProcessorsPassTest.php
@@ -11,13 +11,15 @@
 
 namespace Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Compiler;
 
+use Monolog\Handler\ProcessableHandlerInterface;
+use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\AddProcessorsPass;
-use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\DependencyInjection\Definition;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
 
 class AddProcessorsPassTest extends TestCase
 {
@@ -27,11 +29,27 @@ class AddProcessorsPassTest extends TestCase
 
         $service = $container->getDefinition('monolog.handler.test');
         $calls = $service->getMethodCalls();
-        $this->assertCount(0, $calls);
+        switch (Logger::API) {
+            case 1:
+                $this->assertCount(1, $calls);
+                $this->assertEquals(['pushProcessor', [new Reference('test')]], $calls[0]);
+                break;
+            case 2:
+                $this->assertCount(0, $calls);
+                break;
+        }
 
         $service = $container->getDefinition('handler_test');
         $calls = $service->getMethodCalls();
-        $this->assertCount(0, $calls);
+        switch (Logger::API) {
+            case 1:
+                $this->assertCount(1, $calls);
+                $this->assertEquals(['pushProcessor', [new Reference('test2')]], $calls[0]);
+                break;
+            case 2:
+                $this->assertCount(0, $calls);
+                break;
+        }
     }
 
     protected function getContainer()

--- a/Tests/DependencyInjection/Compiler/AddProcessorsPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddProcessorsPassTest.php
@@ -27,13 +27,11 @@ class AddProcessorsPassTest extends TestCase
 
         $service = $container->getDefinition('monolog.handler.test');
         $calls = $service->getMethodCalls();
-        $this->assertCount(1, $calls);
-        $this->assertEquals(['pushProcessor', [new Reference('test')]], $calls[0]);
+        $this->assertCount(0, $calls);
 
         $service = $container->getDefinition('handler_test');
         $calls = $service->getMethodCalls();
-        $this->assertCount(1, $calls);
-        $this->assertEquals(['pushProcessor', [new Reference('test2')]], $calls[0]);
+        $this->assertCount(0, $calls);
     }
 
     protected function getContainer()

--- a/Tests/DependencyInjection/MonologExtensionTest.php
+++ b/Tests/DependencyInjection/MonologExtensionTest.php
@@ -219,7 +219,16 @@ class MonologExtensionTest extends DependencyInjectionTest
 
         $handler = $container->getDefinition('monolog.handler.dummy');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\NullHandler');
-        $this->assertCount(0, $handler->getMethodCalls());
+        $calls = $handler->getMethodCalls();
+        switch (Logger::API) {
+            case 1:
+                $this->assertCount(1, $calls);
+                $this->assertEquals(['pushProcessor', [new Reference('monolog.processor.psr_log_message')]], $calls[0]);
+                break;
+            case 2:
+                $this->assertCount(0, $calls);
+                break;
+        }
     }
 
     public function testSyslogHandlerWithLogopts()

--- a/Tests/DependencyInjection/MonologExtensionTest.php
+++ b/Tests/DependencyInjection/MonologExtensionTest.php
@@ -210,6 +210,18 @@ class MonologExtensionTest extends DependencyInjectionTest
         $loader->load([['handlers' => ['debug' => ['type' => 'stream']]]], $container);
     }
 
+    public function testNullHandler()
+    {
+        $container = $this->getContainer([['handlers' => ['dummy' => ['type' => 'null']]]]);
+
+        $this->assertTrue($container->hasDefinition('monolog.logger'));
+        $this->assertTrue($container->hasDefinition('monolog.handler.dummy'));
+
+        $handler = $container->getDefinition('monolog.handler.dummy');
+        $this->assertDICDefinitionClass($handler, 'Monolog\Handler\NullHandler');
+        $this->assertCount(0, $handler->getMethodCalls());
+    }
+
     public function testSyslogHandlerWithLogopts()
     {
         $container = $this->getContainer([['handlers' => ['main' => ['type' => 'syslog', 'logopts' => LOG_CONS]]]]);


### PR DESCRIPTION
Since Monolog v2 not all handlers has `pushProcessor()` method, for example `Monolog\Handler\NullHandler`. Thus seems we should check it before add method call to handler's service definition.

Ref #335 