### PR TITLE
Remove invalid handlers

### DIFF
--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -994,13 +994,7 @@ class MonologExtension extends Extension
         $v2HandlerTypesAdded = [
             'elasticsearch' => 'Monolog\Handler\ElasticaHandler',
             'fallbackgroup' => 'Monolog\Handler\FallbackGroupHandler',
-            'logmatic' => 'Monolog\Handler\LogmaticHandler',
             'noop' => 'Monolog\Handler\NoopHandler',
-            'overflow' => 'Monolog\Handler\OverflowHandler',
-            'process' => 'Monolog\Handler\ProcessHandler',
-            'sendgrid' => 'Monolog\Handler\SendGridHandler',
-            'sqs' => 'Monolog\Handler\SqsHandler',
-            'telegram' => 'Monolog\Handler\TelegramBotHandler',
         ];
 
         $v2HandlerTypesRemoved = [

--- a/Tests/DependencyInjection/FixtureMonologExtensionTest.php
+++ b/Tests/DependencyInjection/FixtureMonologExtensionTest.php
@@ -259,6 +259,16 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
         $this->assertNotContainsEquals(['pushProcessor', [new Reference('monolog.processor.psr_log_message')]], $methodCalls, 'The PSR-3 processor should not be enabled');
     }
 
+    public function testHandlersV2()
+    {
+        if (\Monolog\Logger::API < 2) {
+            $this->markTestSkipped('This test requires Monolog v2');
+        }
+        $this->getContainer('handlers');
+
+        $this->expectNotToPerformAssertions();
+    }
+
     public function testPsr3MessageProcessingDisabled()
     {
         $container = $this->getContainer('process_psr_3_messages_disabled');

--- a/Tests/DependencyInjection/Fixtures/xml/handlers.xml
+++ b/Tests/DependencyInjection/Fixtures/xml/handlers.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:monolog="http://symfony.com/schema/dic/monolog"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/monolog http://symfony.com/schema/dic/monolog/monolog-1.0.xsd">
+
+    <monolog:config>
+        <monolog:handler name="noop" type="noop"/>
+    </monolog:config>
+</container>

--- a/Tests/DependencyInjection/Fixtures/yml/handlers.yml
+++ b/Tests/DependencyInjection/Fixtures/yml/handlers.yml
@@ -1,0 +1,4 @@
+monolog:
+    handlers:
+        noop:
+            type: noop


### PR DESCRIPTION
This PR removes the invalid handlers added in #321: Adding an handler is not only about adding the mapping `shortName` <=> `class`: The constructor's arguments have to be defined in the `buildHandler` function. Otherwise, we get the following exception:

```
InvalidArgumentException: Invalid handler type "logmatic" given for handler "logmatic"
                                                                                               
/data/oss/monolog-bundle/DependencyInjection/MonologExtension.php:911
```

This PR adds support for handler "noop". 

Re-adding supports for the other (more complex) handlers could be done in dedicated PR.