### PR TITLE
Add ability to specify custom Sentry hub service

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -212,6 +212,9 @@ use Monolog\Logger;
  *   - [auto_log_stacks]: bool, defaults to false
  *   - [environment]: string, default to null (no env specified)
  *
+ * - sentry:
+ *   - hub_id: Sentry hub custom service id (optional)
+ *
  * - newrelic:
  *   - [level]: level name or int value, defaults to DEBUG
  *   - [bubble]: bool, defaults to true
@@ -639,6 +642,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('connection_timeout')->end() // socket_handler, logentries, pushover, hipchat & slack
                             ->booleanNode('persistent')->end() // socket_handler
                             ->scalarNode('dsn')->end() // raven_handler, sentry_handler
+                            ->scalarNode('hub_id')->defaultNull()->end() // sentry_handler
                             ->scalarNode('client_id')->defaultNull()->end() // raven_handler, sentry_handler
                             ->scalarNode('auto_log_stacks')->defaultFalse()->end() // raven_handler
                             ->scalarNode('release')->defaultNull()->end() // raven_handler, sentry_handler
@@ -860,8 +864,12 @@ class Configuration implements ConfigurationInterface
                             ->thenInvalid('The DSN has to be specified to use a RavenHandler')
                         ->end()
                         ->validate()
-                            ->ifTrue(function ($v) { return 'sentry' === $v['type'] && !array_key_exists('dsn', $v) && null === $v['client_id']; })
+                            ->ifTrue(function ($v) { return 'sentry' === $v['type'] && !array_key_exists('dsn', $v) && null === $v['hub_id'] && null === $v['client_id']; })
                             ->thenInvalid('The DSN has to be specified to use Sentry\'s handler')
+                        ->end()
+                        ->validate()
+                            ->ifTrue(function ($v) { return 'sentry' === $v['type'] && null !== $v['hub_id'] && null !== $v['client_id']; })
+                            ->thenInvalid('You can not use both a hub_id and a client_id in a Sentry handler')
                         ->end()
                         ->validate()
                             ->ifTrue(function ($v) { return 'hipchat' === $v['type'] && (empty($v['token']) || empty($v['room'])); })

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -724,42 +724,46 @@ class MonologExtension extends Extension
             break;
 
         case 'sentry':
-            if (null !== $handler['client_id']) {
-                $clientId = $handler['client_id'];
+            if (null !== $handler['hub_id']) {
+                $hub = new Reference($handler['hub_id']);
             } else {
-                $options = new Definition(
-                    'Sentry\\Options',
-                    [['dsn' => $handler['dsn']]]
+                if (null !== $handler['client_id']) {
+                    $clientId = $handler['client_id'];
+                } else {
+                    $options = new Definition(
+                        'Sentry\\Options',
+                        [['dsn' => $handler['dsn']]]
+                    );
+
+                    if (!empty($handler['environment'])) {
+                        $options->addMethodCall('setEnvironment', [$handler['environment']]);
+                    }
+
+                    if (!empty($handler['release'])) {
+                        $options->addMethodCall('setRelease', [$handler['release']]);
+                    }
+
+                    $builder = new Definition('Sentry\\ClientBuilder', [$options]);
+
+                    $client = new Definition('Sentry\\Client');
+                    $client->setFactory([$builder, 'getClient']);
+
+                    $clientId = 'monolog.sentry.client.'.sha1($handler['dsn']);
+                    $container->setDefinition($clientId, $client);
+
+                    if (!$container->hasAlias('Sentry\\ClientInterface')) {
+                        $container->setAlias('Sentry\\ClientInterface', $clientId);
+                    }
+                }
+
+                $hub = new Definition(
+                    'Sentry\\State\\Hub',
+                    [new Reference($clientId)]
                 );
 
-                if (!empty($handler['environment'])) {
-                    $options->addMethodCall('setEnvironment', [$handler['environment']]);
-                }
-
-                if (!empty($handler['release'])) {
-                    $options->addMethodCall('setRelease', [$handler['release']]);
-                }
-
-                $builder = new Definition('Sentry\\ClientBuilder', [$options]);
-
-                $client = new Definition('Sentry\\Client');
-                $client->setFactory([$builder, 'getClient']);
-
-                $clientId = 'monolog.sentry.client.'.sha1($handler['dsn']);
-                $container->setDefinition($clientId, $client);
-
-                if (!$container->hasAlias('Sentry\\ClientInterface')) {
-                    $container->setAlias('Sentry\\ClientInterface', $clientId);
-                }
+                // can't set the hub to the current hub, getting into a recursion otherwise...
+                //$hub->addMethodCall('setCurrent', array($hub));
             }
-
-            $hub = new Definition(
-                'Sentry\\State\\Hub',
-                [new Reference($clientId)]
-            );
-
-            // can't set the hub to the current hub, getting into a recursion otherwise...
-            //$hub->addMethodCall('setCurrent', array($hub));
 
             $definition->setArguments([
                 $hub,

--- a/Resources/config/schema/monolog-1.0.xsd
+++ b/Resources/config/schema/monolog-1.0.xsd
@@ -67,6 +67,7 @@
         <xsd:attribute name="connection-timeout" type="xsd:string" />
         <xsd:attribute name="persistent" type="xsd:boolean" />
         <xsd:attribute name="dsn" type="xsd:string" />
+        <xsd:attribute name="hub-id" type="xsd:string" />
         <xsd:attribute name="client-id" type="xsd:string" />
         <xsd:attribute name="use-ssl" type="xsd:boolean" />
         <xsd:attribute name="formatter" type="xsd:string" />


### PR DESCRIPTION
As mentioned in https://github.com/getsentry/sentry-docs/pull/3137#discussion_r588942726 , this will allow users to set a custom hub service, eg the one registered by the [Sentry bundle](https://github.com/getsentry/sentry-symfony).