### PR TITLE
Add Sentry Hub instance in DI container to resolve event context issue

### DIFF
--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -757,6 +757,7 @@ class MonologExtension extends Extension
                     'Sentry\\State\\Hub',
                     [new Reference($clientId)]
                 );
+                $container->setDefinition(sprintf('monolog.handler.%s.hub', $name), $hub);
 
                 // can't set the hub to the current hub, getting into a recursion otherwise...
                 //$hub->addMethodCall('setCurrent', array($hub));

--- a/Tests/DependencyInjection/MonologExtensionTest.php
+++ b/Tests/DependencyInjection/MonologExtensionTest.php
@@ -393,6 +393,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         ]]]]);
         $this->assertTrue($container->hasDefinition('monolog.logger'));
         $this->assertTrue($container->hasDefinition('monolog.handler.sentry'));
+        $this->assertTrue($container->hasDefinition('monolog.handler.sentry.hub'));
 
         $logger = $container->getDefinition('monolog.logger');
         $this->assertDICDefinitionMethodCallAt(0, $logger, 'useMicrosecondTimestamps', ['%monolog.use_microseconds%']);
@@ -400,6 +401,10 @@ class MonologExtensionTest extends DependencyInjectionTest
 
         $handler = $container->getDefinition('monolog.handler.sentry');
         $this->assertDICDefinitionClass($handler, 'Sentry\Monolog\Handler');
+
+        $hub = $container->getDefinition('monolog.handler.sentry.hub');
+        $this->assertDICDefinitionClass($hub, 'Sentry\State\Hub');
+        $this->assertDICConstructorArguments($hub, [new Reference('monolog.sentry.client.'.sha1($dsn))]);
     }
 
     public function testSentryHandlerWhenADSNAndAClientAreSpecified()


### PR DESCRIPTION
Fixing Symfony issue with different Hub's while decorating default Sentry handler for extended event context.

Common way to extend log event context is to decorate Sentry\Monolog\Handler:
```php
final class SentryContextHandlerDecorator extends AbstractProcessingHandler
{
    private Handler $handler;

    public function __construct(Handler $handler)
    {
        $this->handler = $handler;

        parent::__construct($handler->getLevel(), $handler->getBubble());
    }

    public function handle(array $record): bool
    {
        $result = false;

        withScope(function (Scope $scope) use ($record, &$result): void {
            if (isset($record['context']) && is_array($record['context']) && count($record['context']) > 0) {
                $scope->setContext('context', $record['context']);
            }

            $result = $this->handler->handle($record);
        });

        return $result;
    }
}
```

But if you do so with Symfony DI, you will get two instances of Hub: one from DI container, and one with SentrySdk in withScope(...) call. Changes to one Hub's scope won't affect second's hub scope.

This PR adds ability to use shared Hub in custom decorators:
```php
App\Logging\Handler\SentryContextHandlerDecorator:
    decorates: monolog.handler.sentry
    arguments:
        - '@App\Logging\Handler\SentryContextHandlerDecorator.inner'
        - '@monolog.handler.sentry.hub'
```
where `sentry` in `monolog.handler.sentry.hub` is name of handler.

Decorator with shared Hub instance:
```php
final class SentryContextHandlerDecorator extends AbstractProcessingHandler
{
    private Handler $handler;
    private Hub $hub;

    public function __construct(Handler $handler, Hub $hub)
    {
        $this->handler = $handler;
        $this->hub = $hub;

        parent::__construct($handler->getLevel(), $handler->getBubble());
    }

    public function handle(array $record): bool
    {
        $result = false;

        $this->hub->withScope(function (Scope $scope) use ($record, &$result): void {
            if (isset($record['context']) && is_array($record['context']) && count($record['context']) > 0) {
                $scope->setContext('context', $record['context']);
            }

            $result = $this->handler->handle($record);
        });

        return $result;
    }
}
```

More comments about problem: https://github.com/getsentry/sentry-php/pull/848#issuecomment-791346614