### PR TITLE
Support for PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/dependency-injection": "^4.4 || ^5.0 || ^6.0",
         "symfony/config": "~4.4 || ^5.0 || ^6.0",
         "symfony/http-kernel": "~4.4 || ^5.0 || ^6.0",
-        "monolog/monolog": "~1.22 || ~2.0"
+        "monolog/monolog": "~1.22 || ~2.1"
     },
     "require-dev": {
         "symfony/yaml": "~4.4 || ^5.0 || ^6.0",


### PR DESCRIPTION
There is an issue when we try to install the monolog bundle with composer using PHP 8.0:

`- monolog/monolog[2.0.0, ..., 2.0.2] require php ^7.2 -> your php version (8.0.8) does not satisfy that requirement.`

So to fix that, we need to upgrade the `monolog/monolog` package from "~2.0" to the version "~2.1", which already added a tentative support for PHP 8.

Check the [changelog file ](https://github.com/Seldaek/monolog/blob/2.1.0/CHANGELOG.md)for more details about the new version. 