### PR TITLE
Add ability to configure the PsrLogMessageProcessor

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -11,11 +11,11 @@
 
 namespace Symfony\Bundle\MonologBundle\DependencyInjection;
 
+use Monolog\Logger;
 use Symfony\Component\Config\Definition\BaseNode;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
-use Monolog\Logger;
 
 /**
  * This class contains the configuration information for the bundle
@@ -390,7 +390,18 @@ class Configuration implements ConfigurationInterface
                             ->booleanNode('bubble')->defaultTrue()->end()
                             ->scalarNode('app_name')->defaultNull()->end()
                             ->booleanNode('include_stacktraces')->defaultFalse()->end()
-                            ->booleanNode('process_psr_3_messages')->defaultNull()->end()
+                            ->arrayNode('process_psr_3_messages')
+                                ->addDefaultsIfNotSet()
+                                ->beforeNormalization()
+                                    ->ifTrue(static function ($v) { return !\is_array($v); })
+                                    ->then(static function ($v) { return ['enabled' => $v]; })
+                                ->end()
+                                ->children()
+                                    ->booleanNode('enabled')->defaultNull()->end()
+                                    ->scalarNode('date_format')->end()
+                                    ->booleanNode('remove_used_context_fields')->end()
+                                ->end()
+                            ->end()
                             ->scalarNode('path')->defaultValue('%kernel.logs_dir%/%kernel.environment%.log')->end() // stream and rotating
                             ->scalarNode('file_permission')  // stream and rotating
                                 ->defaultNull()

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -25,6 +25,7 @@ use Symfony\Bridge\Monolog\Processor\WebProcessor;
 use Symfony\Bundle\FullStack;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Argument\BoundArgument;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -12,9 +12,10 @@
 namespace Symfony\Bundle\MonologBundle\DependencyInjection;
 
 use Monolog\Handler\FingersCrossed\ErrorLevelActivationStrategy;
+use Monolog\Handler\HandlerInterface;
 use Monolog\Logger;
 use Monolog\Processor\ProcessorInterface;
-use Monolog\Handler\HandlerInterface;
+use Monolog\Processor\PsrLogMessageProcessor;
 use Monolog\ResettableInterface;
 use Symfony\Bridge\Monolog\Handler\FingersCrossed\HttpCodeActivationStrategy;
 use Symfony\Bridge\Monolog\Processor\SwitchUserTokenProcessor;
@@ -23,7 +24,6 @@ use Symfony\Bridge\Monolog\Processor\WebProcessor;
 use Symfony\Bundle\FullStack;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Argument\BoundArgument;
-use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
@@ -187,21 +187,13 @@ class MonologExtension extends Extension
             $definition->setConfigurator(['Symfony\\Bundle\\MonologBundle\\MonologBundle', 'includeStacktraces']);
         }
 
-        if (null === $handler['process_psr_3_messages']) {
-            $handler['process_psr_3_messages'] = !isset($handler['handler']) && !$handler['members'];
+        if (null === $handler['process_psr_3_messages']['enabled']) {
+            $handler['process_psr_3_messages']['enabled'] = !isset($handler['handler']) && !$handler['members'];
         }
 
-        if ($handler['process_psr_3_messages']) {
-            if (method_exists($handlerClass, 'pushProcessor')) {
-                $processorId = 'monolog.processor.psr_log_message';
-                if (!$container->hasDefinition($processorId)) {
-                    $processor = new Definition('Monolog\\Processor\\PsrLogMessageProcessor');
-                    $processor->setPublic(false);
-                    $container->setDefinition($processorId, $processor);
-                }
-
-                $definition->addMethodCall('pushProcessor', [new Reference($processorId)]);
-            }
+        if ($handler['process_psr_3_messages']['enabled'] && method_exists($handlerClass, 'pushProcessor')) {
+            $processorId = $this->buildPsrLogMessageProcessor($container, $handler['process_psr_3_messages']);
+            $definition->addMethodCall('pushProcessor', [new Reference($processorId)]);
         }
 
         switch ($handler['type']) {
@@ -1022,5 +1014,41 @@ class MonologExtension extends Extension
         }
 
         return $typeToClassMapping[$handlerType];
+    }
+
+    private function buildPsrLogMessageProcessor(ContainerBuilder $container, array $processorOptions): string
+    {
+        static $hasConstructorArguments;
+
+        if (!isset($hasConstructorArguments)) {
+            $reflectionConstructor = (new \ReflectionClass(PsrLogMessageProcessor::class))->getConstructor();
+            $hasConstructorArguments = null !== $reflectionConstructor && $reflectionConstructor->getNumberOfParameters() > 0;
+            unset($reflectionConstructor);
+        }
+
+        $processorId = 'monolog.processor.psr_log_message';
+        $processorArguments = [];
+
+        unset($processorOptions['enabled']);
+
+        if (!empty($processorOptions)) {
+            if (!$hasConstructorArguments) {
+                throw new \RuntimeException('Monolog 1.26 or higher is required for the "date_format" and "remove_used_context_fields" options to be used.');
+            }
+            $processorArguments = [
+                $processorOptions['date_format'] ?? null,
+                $processorOptions['remove_used_context_fields'] ?? false,
+            ];
+            $processorId .= '.'.ContainerBuilder::hash($processorArguments);
+        }
+
+        if (!$container->hasDefinition($processorId)) {
+            $processor = new Definition(PsrLogMessageProcessor::class);
+            $processor->setPublic(false);
+            $processor->setArguments($processorArguments);
+            $container->setDefinition($processorId, $processor);
+        }
+
+        return $processorId;
     }
 }

--- a/Resources/config/schema/monolog-1.0.xsd
+++ b/Resources/config/schema/monolog-1.0.xsd
@@ -29,6 +29,7 @@
             <xsd:element name="accepted-level" type="level" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="to-email" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="header" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="process-psr-3-messages" type="process-psr-3-messages" minOccurs="0" maxOccurs="1" />
         </xsd:sequence>
         <xsd:attribute name="type" type="xsd:string" />
         <xsd:attribute name="priority" type="xsd:integer" />
@@ -192,7 +193,13 @@
 
     <xsd:complexType name="headers">
         <xsd:sequence>
-            <xsd:any minOccurs="0" processContents="lax"/>
+            <xsd:any minOccurs="0" processContents="lax" />
         </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="process-psr-3-messages">
+        <xsd:attribute name="enabled" type="xsd:boolean" />
+        <xsd:attribute name="date-format" type="xsd:string" />
+        <xsd:attribute name="remove-used-context-fields" type="xsd:boolean" />
     </xsd:complexType>
 </xsd:schema>

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -490,6 +490,41 @@ class ConfigurationTest extends TestCase
     }
 
     /**
+     * @dataProvider processPsr3MessagesProvider
+     */
+    public function testWithProcessPsr3Messages(array $configuration, array $processedConfiguration): void
+    {
+        $configs = [
+            [
+                'handlers' => [
+                    'main' => ['type' => 'stream'] + $configuration,
+                ],
+            ],
+        ];
+
+        $config = $this->process($configs);
+
+        $this->assertEquals($processedConfiguration, $config['handlers']['main']['process_psr_3_messages']);
+    }
+
+    public function processPsr3MessagesProvider(): iterable
+    {
+        yield 'Not specified' => [[], ['enabled' => null]];
+        yield 'Null' => [['process_psr_3_messages' => null], ['enabled' => true]];
+        yield 'True' => [['process_psr_3_messages' => true], ['enabled' => true]];
+        yield 'False' => [['process_psr_3_messages' => false], ['enabled' => false]];
+
+        yield 'Date format' => [
+            ['process_psr_3_messages' => ['date_format' => 'Y']],
+            ['date_format' => 'Y', 'enabled' => null],
+        ];
+        yield 'Enabled false & remove used' => [
+            ['process_psr_3_messages' => ['enabled' => false, 'remove_used_context_fields' => true]],
+            ['enabled' => false, 'remove_used_context_fields' => true],
+        ];
+    }
+
+    /**
      * Processes an array of configurations and returns a compiled version.
      *
      * @param array $configs An array of raw configurations

--- a/Tests/DependencyInjection/Fixtures/xml/process_psr_3_messages_with_arguments.xml
+++ b/Tests/DependencyInjection/Fixtures/xml/process_psr_3_messages_with_arguments.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:monolog="http://symfony.com/schema/dic/monolog"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/monolog http://symfony.com/schema/dic/monolog/monolog-1.0.xsd">
+    <monolog:config>
+        <monolog:handler name="with_arguments" type="stream">
+            <monolog:process-psr-3-messages date-format="Y" />
+        </monolog:handler>
+        <monolog:handler name="without_arguments" type="stream">
+            <monolog:process-psr-3-messages enabled="true" />
+        </monolog:handler>
+    </monolog:config>
+</container>

--- a/Tests/DependencyInjection/Fixtures/xml/process_psr_3_messages_without_arguments.xml
+++ b/Tests/DependencyInjection/Fixtures/xml/process_psr_3_messages_without_arguments.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:monolog="http://symfony.com/schema/dic/monolog"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/monolog http://symfony.com/schema/dic/monolog/monolog-1.0.xsd">
+    <monolog:config>
+        <monolog:handler name="without_arguments" type="stream">
+            <monolog:process-psr-3-messages enabled="true" />
+        </monolog:handler>
+    </monolog:config>
+</container>

--- a/Tests/DependencyInjection/Fixtures/yml/process_psr_3_messages_with_arguments.yml
+++ b/Tests/DependencyInjection/Fixtures/yml/process_psr_3_messages_with_arguments.yml
@@ -1,0 +1,10 @@
+monolog:
+    handlers:
+        with_arguments:
+            type: stream
+            process_psr_3_messages:
+                date_format: 'Y'
+        without_arguments:
+            type: stream
+            process_psr_3_messages:
+                enabled: true

--- a/Tests/DependencyInjection/Fixtures/yml/process_psr_3_messages_without_arguments.yml
+++ b/Tests/DependencyInjection/Fixtures/yml/process_psr_3_messages_without_arguments.yml
@@ -1,0 +1,6 @@
+monolog:
+    handlers:
+        without_arguments:
+            type: stream
+            process_psr_3_messages:
+                enabled: true


### PR DESCRIPTION
Adds the ability to configure the PsrLogMessageProcessor using semantic configuration.

See https://github.com/Seldaek/monolog/pull/940, https://github.com/Seldaek/monolog/pull/1046, https://github.com/Seldaek/monolog/pull/1487.