### PR TITLE
Add flag for filling sentry extra context

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -391,7 +391,7 @@ class Configuration implements ConfigurationInterface
                             ->booleanNode('bubble')->defaultTrue()->end()
                             ->scalarNode('app_name')->defaultNull()->end()
                             ->booleanNode('include_stacktraces')->defaultFalse()->end()
-                            ->booleanNode('fill_extra_context')->defaultFalse()->end()
+                            ->booleanNode('fill_extra_context')->defaultFalse()->end() // sentry
                             ->booleanNode('process_psr_3_messages')->defaultNull()->end()
                             ->scalarNode('path')->defaultValue('%kernel.logs_dir%/%kernel.environment%.log')->end() // stream and rotating
                             ->scalarNode('file_permission')  // stream and rotating

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -219,6 +219,7 @@ use Monolog\Logger;
  *
  * - sentry:
  *   - hub_id: Sentry hub custom service id (optional)
+ *   - [fill_extra_context]: bool, defaults to false
  *
  * - newrelic:
  *   - [level]: level name or int value, defaults to DEBUG
@@ -390,6 +391,7 @@ class Configuration implements ConfigurationInterface
                             ->booleanNode('bubble')->defaultTrue()->end()
                             ->scalarNode('app_name')->defaultNull()->end()
                             ->booleanNode('include_stacktraces')->defaultFalse()->end()
+                            ->booleanNode('fill_extra_context')->defaultFalse()->end()
                             ->booleanNode('process_psr_3_messages')->defaultNull()->end()
                             ->scalarNode('path')->defaultValue('%kernel.logs_dir%/%kernel.environment%.log')->end() // stream and rotating
                             ->scalarNode('file_permission')  // stream and rotating

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -767,6 +767,7 @@ class MonologExtension extends Extension
                 $hub,
                 $handler['level'],
                 $handler['bubble'],
+                $handler['fill_extra_context'],
             ]);
             break;
 

--- a/Tests/DependencyInjection/MonologExtensionTest.php
+++ b/Tests/DependencyInjection/MonologExtensionTest.php
@@ -484,7 +484,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.sentry')]);
 
         $handler = $container->getDefinition('monolog.handler.sentry');
-        $this->assertDICConstructorArguments($handler, [new Reference('sentry.hub'), \Monolog\Logger::DEBUG, true]);
+        $this->assertDICConstructorArguments($handler, [new Reference('sentry.hub'), \Monolog\Logger::DEBUG, true, false]);
     }
 
     public function testSentryHandlerWhenAHubAndAClientAreSpecified()


### PR DESCRIPTION
Due to updates in sentry php library which allowing to fill extra context data in [3.4.0](https://github.com/getsentry/sentry-php/blob/master/CHANGELOG.md#340-2022-03-14) added corresponding flag for handler.