### PR TITLE
Resolve "level" env var at runtime

### DIFF
--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -189,6 +189,7 @@ class ConfigurationTest extends TestCase
         $config = $this->process($configs);
     }
 
+    /** @group legacy */
     public function testWithSwiftMailerHandler()
     {
         if (\Monolog\Logger::API >= 3) {

--- a/Tests/DependencyInjection/FixtureMonologExtensionTest.php
+++ b/Tests/DependencyInjection/FixtureMonologExtensionTest.php
@@ -29,7 +29,7 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
             $this->markTestSkipped('Symfony MonologBridge < 5.2 is needed.');
         }
 
-        $this->doTestLoadWithSeveralHandlers(\Monolog\Logger::ERROR);
+        $this->doTestLoadWithSeveralHandlers('ERROR');
     }
 
     public function testLoadWithSeveralHandlers()
@@ -38,7 +38,7 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
             $this->markTestSkipped('Symfony MonologBridge >= 5.2 is needed.');
         }
 
-        $this->doTestLoadWithSeveralHandlers(new Definition(ErrorLevelActivationStrategy::class, [\Monolog\Logger::ERROR]));
+        $this->doTestLoadWithSeveralHandlers(new Definition(ErrorLevelActivationStrategy::class, ['ERROR']));
     }
 
     private function doTestLoadWithSeveralHandlers($activation)
@@ -59,15 +59,15 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
 
         $handler = $container->getDefinition('monolog.handler.custom');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
-        $this->assertDICConstructorArguments($handler, ['/tmp/symfony.log', \Monolog\Logger::ERROR, false, 0666, false]);
+        $this->assertDICConstructorArguments($handler, ['/tmp/symfony.log', 'ERROR', false, 0666, false]);
 
         $handler = $container->getDefinition('monolog.handler.main');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\FingersCrossedHandler');
-        $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested'), $activation, 0, true, true, \Monolog\Logger::NOTICE]);
+        $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested'), $activation, 0, true, true, 'NOTICE']);
 
         $handler = $container->getDefinition('monolog.handler.filtered');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\FilterHandler');
-        $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested2'), [\Monolog\Logger::WARNING, \Monolog\Logger::ERROR], \Monolog\Logger::EMERGENCY, true]);
+        $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested2'), ['WARNING', 'ERROR'], 'EMERGENCY', true]);
     }
 
     /** @group legacy */
@@ -77,7 +77,7 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
             $this->markTestSkipped('Symfony MonologBridge < 5.2 is needed.');
         }
 
-        $this->doTestLoadWithOverwriting(\Monolog\Logger::ERROR);
+        $this->doTestLoadWithOverwriting('ERROR');
     }
 
     public function testLoadWithOverwriting()
@@ -86,7 +86,7 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
             $this->markTestSkipped('Symfony MonologBridge >= 5.2 is needed.');
         }
 
-        $this->doTestLoadWithOverwriting(new Definition(ErrorLevelActivationStrategy::class, [\Monolog\Logger::ERROR]));
+        $this->doTestLoadWithOverwriting(new Definition(ErrorLevelActivationStrategy::class, ['ERROR']));
     }
 
     private function doTestLoadWithOverwriting($activation)
@@ -106,7 +106,7 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
 
         $handler = $container->getDefinition('monolog.handler.custom');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
-        $this->assertDICConstructorArguments($handler, ['/tmp/symfony.log', \Monolog\Logger::WARNING, true, null, false]);
+        $this->assertDICConstructorArguments($handler, ['/tmp/symfony.log', 'WARNING', true, null, false]);
 
         $handler = $container->getDefinition('monolog.handler.main');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\FingersCrossedHandler');
@@ -132,7 +132,7 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
 
         $handler = $container->getDefinition('monolog.handler.new');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
-        $this->assertDICConstructorArguments($handler, ['/tmp/monolog.log', \Monolog\Logger::ERROR, true, null, false]);
+        $this->assertDICConstructorArguments($handler, ['/tmp/monolog.log', 'ERROR', true, null, false]);
     }
 
     public function testLoadWithNewAndPriority()
@@ -156,15 +156,15 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
 
         $handler = $container->getDefinition('monolog.handler.main');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\BufferHandler');
-        $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested'), 0, \Monolog\Logger::INFO, true, false]);
+        $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested'), 0, 'INFO', true, false]);
 
         $handler = $container->getDefinition('monolog.handler.first');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\RotatingFileHandler');
-        $this->assertDICConstructorArguments($handler, ['/tmp/monolog.log', 0, \Monolog\Logger::ERROR, true, null, false]);
+        $this->assertDICConstructorArguments($handler, ['/tmp/monolog.log', 0, 'ERROR', true, null, false]);
 
         $handler = $container->getDefinition('monolog.handler.last');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
-        $this->assertDICConstructorArguments($handler, ['/tmp/last.log', \Monolog\Logger::ERROR, true, null, false]);
+        $this->assertDICConstructorArguments($handler, ['/tmp/last.log', 'ERROR', true, null, false]);
     }
 
     public function testHandlersWithChannels()
@@ -209,7 +209,7 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
 
         $this->assertEquals([
             '0:9911',
-            100,
+            'DEBUG',
             true,
         ], $container->getDefinition('monolog.handler.server_log')->getArguments());
     }

--- a/Tests/DependencyInjection/MonologExtensionTest.php
+++ b/Tests/DependencyInjection/MonologExtensionTest.php
@@ -44,7 +44,7 @@ class MonologExtensionTest extends DependencyInjectionTest
 
         $handler = $container->getDefinition('monolog.handler.main');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
-        $this->assertDICConstructorArguments($handler, ['%kernel.logs_dir%/%kernel.environment%.log', \Monolog\Logger::DEBUG, true, null, false]);
+        $this->assertDICConstructorArguments($handler, ['%kernel.logs_dir%/%kernel.environment%.log', 'DEBUG', true, null, false]);
         $this->assertDICDefinitionMethodCallAt(0, $handler, 'pushProcessor', [new Reference('monolog.processor.psr_log_message')]);
     }
 
@@ -62,16 +62,7 @@ class MonologExtensionTest extends DependencyInjectionTest
 
         $handler = $container->getDefinition('monolog.handler.custom');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
-        $this->assertDICConstructorArguments($handler, ['/tmp/symfony.log', \Monolog\Logger::ERROR, false, 0666, true]);
-    }
-
-    public function testLoadWithUnknownLevel()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Could not match "warn" to a log level.');
-        $container = $this->getContainer([['handlers' => [
-            'custom' => ['type' => 'stream', 'path' => '/tmp/symfony.log', 'bubble' => false, 'level' => 'warn', 'file_permission' => '0666', 'use_locking' => true]
-        ]]]);
+        $this->assertDICConstructorArguments($handler, ['/tmp/symfony.log', 'ERROR', false, 0666, true]);
     }
 
     public function testLoadWithNestedHandler()
@@ -91,7 +82,7 @@ class MonologExtensionTest extends DependencyInjectionTest
 
         $handler = $container->getDefinition('monolog.handler.custom');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\StreamHandler');
-        $this->assertDICConstructorArguments($handler, ['/tmp/symfony.log', \Monolog\Logger::ERROR, false, 0666, false]);
+        $this->assertDICConstructorArguments($handler, ['/tmp/symfony.log', 'ERROR', false, 0666, false]);
     }
 
     public function testLoadWithServiceHandler()
@@ -228,7 +219,7 @@ class MonologExtensionTest extends DependencyInjectionTest
 
         $handler = $container->getDefinition('monolog.handler.main');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\SyslogHandler');
-        $this->assertDICConstructorArguments($handler, [false, 'user', \Monolog\Logger::DEBUG, true, LOG_CONS]);
+        $this->assertDICConstructorArguments($handler, [false, 'user', 'DEBUG', true, LOG_CONS]);
     }
 
     public function testRollbarHandlerCreatesNotifier()
@@ -244,7 +235,7 @@ class MonologExtensionTest extends DependencyInjectionTest
 
         $handler = $container->getDefinition('monolog.handler.main');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\RollbarHandler');
-        $this->assertDICConstructorArguments($handler, [new Reference('monolog.rollbar.notifier.1c8e6a67728dff6a209f828427128dd8b3c2b746'), \Monolog\Logger::DEBUG, true]);
+        $this->assertDICConstructorArguments($handler, [new Reference('monolog.rollbar.notifier.1c8e6a67728dff6a209f828427128dd8b3c2b746'), 'DEBUG', true]);
     }
 
     public function testRollbarHandlerReusesNotifier()
@@ -263,7 +254,7 @@ class MonologExtensionTest extends DependencyInjectionTest
 
         $handler = $container->getDefinition('monolog.handler.main');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\RollbarHandler');
-        $this->assertDICConstructorArguments($handler, [new Reference('my_rollbar_id'), \Monolog\Logger::DEBUG, true]);
+        $this->assertDICConstructorArguments($handler, [new Reference('my_rollbar_id'), 'DEBUG', true]);
     }
 
     public function testSocketHandler()
@@ -288,7 +279,7 @@ class MonologExtensionTest extends DependencyInjectionTest
 
         $handler = $container->getDefinition('monolog.handler.socket');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\SocketHandler');
-        $this->assertDICConstructorArguments($handler, ['localhost:50505', \Monolog\Logger::DEBUG, true]);
+        $this->assertDICConstructorArguments($handler, ['localhost:50505', 'DEBUG', true]);
         $this->assertDICDefinitionMethodCallAt(0, $handler, 'pushProcessor', [new Reference('monolog.processor.psr_log_message')]);
         $this->assertDICDefinitionMethodCallAt(1, $handler, 'setTimeout', ['1']);
         $this->assertDICDefinitionMethodCallAt(2, $handler, 'setConnectionTimeout', ['0.6']);
@@ -354,7 +345,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.raven')]);
 
         $handler = $container->getDefinition('monolog.handler.raven');
-        $this->assertDICConstructorArguments($handler, [new Reference('raven.client'), 100, true]);
+        $this->assertDICConstructorArguments($handler, [new Reference('raven.client'), 'DEBUG', true]);
     }
 
     public function testRavenHandlerWhenAClientIsSpecified()
@@ -374,7 +365,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.raven')]);
 
         $handler = $container->getDefinition('monolog.handler.raven');
-        $this->assertDICConstructorArguments($handler, [new Reference('raven.client'), 100, true]);
+        $this->assertDICConstructorArguments($handler, [new Reference('raven.client'), 'DEBUG', true]);
     }
 
     public function testSentryHandlerWhenConfigurationIsWrong()
@@ -487,7 +478,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.sentry')]);
 
         $handler = $container->getDefinition('monolog.handler.sentry');
-        $this->assertDICConstructorArguments($handler, [new Reference('sentry.hub'), \Monolog\Logger::DEBUG, true, false]);
+        $this->assertDICConstructorArguments($handler, [new Reference('sentry.hub'), 'DEBUG', true, false]);
     }
 
     public function testSentryHandlerWhenAHubAndAClientAreSpecified()
@@ -540,7 +531,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         $this->assertDICDefinitionMethodCallAt(1, $logger, 'pushHandler', [new Reference('monolog.handler.loggly')]);
         $handler = $container->getDefinition('monolog.handler.loggly');
         $this->assertDICDefinitionClass($handler, 'Monolog\Handler\LogglyHandler');
-        $this->assertDICConstructorArguments($handler, [$token, \Monolog\Logger::DEBUG, true]);
+        $this->assertDICConstructorArguments($handler, [$token, 'DEBUG', true]);
         $this->assertDICDefinitionMethodCallAt(0, $handler, 'pushProcessor', [new Reference('monolog.processor.psr_log_message')]);
 
         $container = $this->getContainer([['handlers' => ['loggly' => [
@@ -558,7 +549,7 @@ class MonologExtensionTest extends DependencyInjectionTest
             $this->markTestSkipped('Symfony MonologBridge < 5.2 is needed.');
         }
 
-        $this->doTestFingersCrossedHandlerWhenExcluded404sAreSpecified(\Monolog\Logger::WARNING);
+        $this->doTestFingersCrossedHandlerWhenExcluded404sAreSpecified('WARNING');
     }
 
     /** @group legacy */
@@ -568,7 +559,7 @@ class MonologExtensionTest extends DependencyInjectionTest
             $this->markTestSkipped('Symfony MonologBridge >= 5.2 is needed.');
         }
 
-        $this->doTestFingersCrossedHandlerWhenExcluded404sAreSpecified(new Definition(ErrorLevelActivationStrategy::class, [\Monolog\Logger::WARNING]));
+        $this->doTestFingersCrossedHandlerWhenExcluded404sAreSpecified(new Definition(ErrorLevelActivationStrategy::class, ['WARNING']));
     }
 
     private function doTestFingersCrossedHandlerWhenExcluded404sAreSpecified($activation)
@@ -603,7 +594,7 @@ class MonologExtensionTest extends DependencyInjectionTest
             $this->markTestSkipped('Symfony MonologBridge < 5.2 is needed.');
         }
 
-        $this->doTestFingersCrossedHandlerWhenExcludedHttpCodesAreSpecified(\Monolog\Logger::WARNING);
+        $this->doTestFingersCrossedHandlerWhenExcludedHttpCodesAreSpecified('WARNING');
     }
 
     public function testFingersCrossedHandlerWhenExcludedHttpCodesAreSpecified()
@@ -612,7 +603,7 @@ class MonologExtensionTest extends DependencyInjectionTest
             $this->markTestSkipped('Symfony MonologBridge >= 5.2 is needed.');
         }
 
-        $this->doTestFingersCrossedHandlerWhenExcludedHttpCodesAreSpecified(new Definition(ErrorLevelActivationStrategy::class, [\Monolog\Logger::WARNING]));
+        $this->doTestFingersCrossedHandlerWhenExcludedHttpCodesAreSpecified(new Definition(ErrorLevelActivationStrategy::class, ['WARNING']));
     }
 
     private function doTestFingersCrossedHandlerWhenExcludedHttpCodesAreSpecified($activation)
@@ -716,18 +707,6 @@ class MonologExtensionTest extends DependencyInjectionTest
         ];
     }
 
-    public function testLogLevelfromInvalidparameterThrowsException()
-    {
-        $container = new ContainerBuilder();
-        $loader = new MonologExtension();
-        $config = [['handlers' => ['main' => ['type' => 'stream', 'level' => '%some_param%']]]];
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Could not match "%some_param%" to a log level.');
-
-        $loader->load($config, $container);
-    }
-
     /**
      * @dataProvider provideLoglevelParameterConfig
      */
@@ -753,13 +732,19 @@ class MonologExtensionTest extends DependencyInjectionTest
                 ['%log_level%' => 'info'],
                 ['type' => 'browser_console', 'level' => '%log_level%'],
                 'Monolog\Handler\BrowserConsoleHandler',
-                [200, true]
+                [
+                    '%log_level%',
+                    true,
+                ]
             ],
             'browser console with envvar level' => [
                 ['%env(LOG_LEVEL)%' => 'info'],
                 ['type' => 'browser_console', 'level' => '%env(LOG_LEVEL)%'],
                 'Monolog\Handler\BrowserConsoleHandler',
-                [200, true]
+                [
+                    '%env(LOG_LEVEL)%',
+                    true,
+                ]
             ],
             'stream with envvar level null or "~" (in yaml config)' => [
                 ['%env(LOG_LEVEL)%' => null],
@@ -767,7 +752,7 @@ class MonologExtensionTest extends DependencyInjectionTest
                 'Monolog\Handler\StreamHandler',
                 [
                     '%kernel.logs_dir%/%kernel.environment%.log',
-                    null,
+                    '%env(LOG_LEVEL)%',
                     true,
                     null,
                     false,
@@ -779,7 +764,7 @@ class MonologExtensionTest extends DependencyInjectionTest
                 'Monolog\Handler\StreamHandler',
                 [
                     '%kernel.logs_dir%/%kernel.environment%.log',
-                    400,
+                    '%env(LOG_LEVEL)%',
                     true,
                     null,
                     false,
@@ -791,7 +776,7 @@ class MonologExtensionTest extends DependencyInjectionTest
                 'Monolog\Handler\StreamHandler',
                 [
                     '%kernel.logs_dir%/%kernel.environment%.log',
-                    500,
+                    '%log_level%',
                     true,
                     null,
                     false,


### PR DESCRIPTION
Resolves #413, #444

Currently, the log level is read when the container built. This means we cannot change a log level at runtime using env vars.

With this change, log level can be modified for a specific command run: `LOG_LEVEL=debug bin/console ...`

~I would like to get some feedbacks before updating tests. I don't know yet what is the best strategy to check the resolution of the values.~