### PR TITLE
Fix Swiftmailer deprecation notice

### DIFF
--- a/Tests/DependencyInjection/FixtureMonologExtensionTest.php
+++ b/Tests/DependencyInjection/FixtureMonologExtensionTest.php
@@ -182,6 +182,7 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
         );
     }
 
+    /** @group legacy */
     public function testSingleEmailRecipient()
     {
         if (\Monolog\Logger::API >= 3) {


### PR DESCRIPTION
```
Remaining direct deprecation notices (1)

  1x: Since symfony/monolog-bridge 5.4: "Symfony\Bridge\Monolog\Handler\SwiftMailerHandler" is deprecated and will be removed in 6.0.
    1x in XmlMonologExtensionTest::testSingleEmailRecipient from Symfony\Bundle\MonologBundle\Tests\DependencyInjection
```