### PR TITLE
Fix test for autoconfiguration

### DIFF
--- a/Tests/DependencyInjection/Fixtures/AsMonologProcessor/FooProcessorWithPriority.php
+++ b/Tests/DependencyInjection/Fixtures/AsMonologProcessor/FooProcessorWithPriority.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Fixtures\AsMonologProcessor;
+
+use Monolog\Attribute\AsMonologProcessor;
+
+#[AsMonologProcessor(handler: 'foo_handler')]
+class FooProcessorWithPriority
+{
+    #[AsMonologProcessor(channel: 'ccc_channel', priority: '10')]
+    public function __invoke(): void
+    {
+    }
+}


### PR DESCRIPTION
This PR contains two small fixes for the Monolog processor autoconfiguration test. The test currently fails because of changes in https://github.com/Seldaek/monolog/pull/1797.

Not sure if I should provide more information. Please let me know if I missed something 🙂 