### PR TITLE
Drop Support for Symfony 4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,6 @@ jobs:
                 php: [ '7.2', '7.3', '7.4', '8.0', '8.1' ]
                 monolog: [ '1.*', '2.*' ]
                 include:
-                    -   php: '7.1'
                     -   php: '7.4'
                         deps: lowest
                         deprecations: max[self]=0

--- a/DependencyInjection/Compiler/LoggerChannelPass.php
+++ b/DependencyInjection/Compiler/LoggerChannelPass.php
@@ -66,19 +66,17 @@ class LoggerChannelPass implements CompilerPassInterface
                 }
                 $definition->setMethodCalls($calls);
 
-                if (\method_exists($definition, 'getBindings')) {
-                    $binding = new BoundArgument(new Reference($loggerId));
+                $binding = new BoundArgument(new Reference($loggerId));
 
-                    // Mark the binding as used already, to avoid reporting it as unused if the service does not use a
-                    // logger injected through the LoggerInterface alias.
-                    $values = $binding->getValues();
-                    $values[2] = true;
-                    $binding->setValues($values);
+                // Mark the binding as used already, to avoid reporting it as unused if the service does not use a
+                // logger injected through the LoggerInterface alias.
+                $values = $binding->getValues();
+                $values[2] = true;
+                $binding->setValues($values);
 
-                    $bindings = $definition->getBindings();
-                    $bindings['Psr\Log\LoggerInterface'] = $binding;
-                    $definition->setBindings($bindings);
-                }
+                $bindings = $definition->getBindings();
+                $bindings['Psr\Log\LoggerInterface'] = $binding;
+                $definition->setBindings($bindings);
             }
         }
 
@@ -117,11 +115,9 @@ class LoggerChannelPass implements CompilerPassInterface
     }
 
     /**
-     * @param array $configuration
-     *
      * @return array
      */
-    protected function processChannels($configuration)
+    protected function processChannels(?array $configuration)
     {
         if (null === $configuration) {
             return $this->channels;
@@ -137,11 +133,9 @@ class LoggerChannelPass implements CompilerPassInterface
     /**
      * Create new logger from the monolog.logger_prototype
      *
-     * @param string $channel
-     * @param string $loggerId
-     * @param ContainerBuilder $container
+     * @return void
      */
-    protected function createLogger($channel, $loggerId, ContainerBuilder $container)
+    protected function createLogger(string $channel, string $loggerId, ContainerBuilder $container)
     {
         if (!in_array($channel, $this->channels)) {
             $logger = new ChildDefinition('monolog.logger_prototype');
@@ -150,29 +144,16 @@ class LoggerChannelPass implements CompilerPassInterface
             $this->channels[] = $channel;
         }
 
-        // Allows only for Symfony 4.2+
-        if (\method_exists($container, 'registerAliasForArgument')) {
-            $parameterName = $channel . 'Logger';
+        $parameterName = $channel . 'Logger';
 
-            $container->registerAliasForArgument($loggerId, LoggerInterface::class, $parameterName);
-        }
+        $container->registerAliasForArgument($loggerId, LoggerInterface::class, $parameterName);
     }
 
     /**
      * Creates a copy of a reference and alters the service ID.
-     *
-     * @param Reference $reference
-     * @param string    $serviceId
-     *
-     * @return Reference
      */
-    private function changeReference(Reference $reference, $serviceId)
+    private function changeReference(Reference $reference, string $serviceId): Reference
     {
-        if (method_exists($reference, 'isStrict')) {
-            // Stay compatible with Symfony 2
-            return new Reference($serviceId, $reference->getInvalidBehavior(), $reference->isStrict(false));
-        }
-
         return new Reference($serviceId, $reference->getInvalidBehavior());
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -379,7 +379,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('monolog');
-        $rootNode = method_exists(TreeBuilder::class, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('monolog');
+        $rootNode = $treeBuilder->getRootNode();
 
         $handlers = $rootNode
             ->fixXmlConfig('channel')
@@ -602,7 +602,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                  // console
                 ->variableNode('console_formater_options')
-                    ->setDeprecated(...$this->getDeprecationMsg('"%path%.%node%" is deprecated, use "%path%.console_formatter_options" instead.', 3.7))
+                    ->setDeprecated('symfony/monolog-bundle', 3.7, '"%path%.%node%" is deprecated, use "%path%.console_formatter_options" instead.')
                     ->validate()
                         ->ifTrue(function ($v) {
                             return !is_array($v);
@@ -1134,28 +1134,5 @@ class Configuration implements ConfigurationInterface
                 ->end()
             ->end()
         ;
-    }
-
-    /**
-     * Returns the correct deprecation param's as an array for setDeprecated.
-     *
-     * Symfony/Config v5.1 introduces a deprecation notice when calling
-     * setDeprecation() with less than 3 args and the getDeprecation method was
-     * introduced at the same time. By checking if getDeprecation() exists,
-     * we can determine the correct param count to use when calling setDeprecated.
-     *
-     * @return array{0:string}|array{0:string, 1: numeric-string, string}
-     */
-    private function getDeprecationMsg(string $message, string $version): array
-    {
-        if (method_exists(BaseNode::class, 'getDeprecation')) {
-            return [
-                'symfony/monolog-bundle',
-                $version,
-                $message,
-            ];
-        }
-
-        return [$message];
     }
 }

--- a/MonologBundle.php
+++ b/MonologBundle.php
@@ -27,14 +27,14 @@ use Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\FixEmptyLoggerPass
  */
 class MonologBundle extends Bundle
 {
+    /**
+     * @return void
+     */
     public function build(ContainerBuilder $container)
     {
         parent::build($container);
 
         $container->addCompilerPass($channelPass = new LoggerChannelPass());
-        if (!class_exists('Symfony\Bridge\Monolog\Processor\DebugProcessor') || !class_exists('Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddDebugLogProcessorPass')) {
-            $container->addCompilerPass(new DebugHandlerPass($channelPass));
-        }
         $container->addCompilerPass(new FixEmptyLoggerPass($channelPass));
         $container->addCompilerPass(new AddProcessorsPass());
         $container->addCompilerPass(new AddSwiftMailerTransportPass());
@@ -42,6 +42,7 @@ class MonologBundle extends Bundle
 
     /**
      * @internal
+     * @return void
      */
     public static function includeStacktraces(HandlerInterface $handler)
     {

--- a/Tests/DependencyInjection/Compiler/LoggerChannelPassTest.php
+++ b/Tests/DependencyInjection/Compiler/LoggerChannelPassTest.php
@@ -56,10 +56,6 @@ class LoggerChannelPassTest extends TestCase
 
     public function testTypeHintedAliasesExistForEachChannel()
     {
-        if (!\method_exists(ContainerBuilder::class, 'registerAliasForArgument')) {
-            $this->markTestSkipped('Need DependencyInjection 4.2+ to register type-hinted aliases for channels.');
-        }
-
         $container = $this->getContainer();
         $expectedChannels = ['test', 'foo', 'bar', 'additional'];
 
@@ -81,10 +77,6 @@ class LoggerChannelPassTest extends TestCase
 
     public function testAutowiredLoggerArgumentsAreReplacedWithChannelLogger()
     {
-        if (!\method_exists('Symfony\Component\DependencyInjection\Definition', 'getBindings')) {
-            $this->markTestSkipped('Need DependencyInjection 3.4+ to autowire channel logger.');
-        }
-
         $container = $this->getFunctionalContainer();
 
         $dummyService = $container->register('dummy_service', 'Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Compiler\DummyService')
@@ -99,10 +91,6 @@ class LoggerChannelPassTest extends TestCase
 
     public function testAutowiredLoggerArgumentsAreReplacedWithChannelLoggerWhenAutoconfigured()
     {
-        if (!\method_exists('Symfony\Component\DependencyInjection\Definition', 'getBindings')) {
-            $this->markTestSkipped('Need DependencyInjection 3.4+ to autowire channel logger.');
-        }
-
         $container = $this->getFunctionalContainer();
 
         $container->registerForAutoconfiguration('Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Compiler\DummyService')
@@ -121,10 +109,6 @@ class LoggerChannelPassTest extends TestCase
 
     public function testAutowiredLoggerArgumentsAreNotReplacedWithChannelLoggerIfLoggerArgumentIsConfiguredExplicitly()
     {
-        if (!\method_exists('Symfony\Component\DependencyInjection\Definition', 'getBindings')) {
-            $this->markTestSkipped('Need DependencyInjection 3.4+ to autowire channel logger.');
-        }
-
         $container = $this->getFunctionalContainer();
 
         $dummyService = $container->register('dummy_service', 'Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Compiler\DummyService')

--- a/Tests/DependencyInjection/FixtureMonologExtensionTest.php
+++ b/Tests/DependencyInjection/FixtureMonologExtensionTest.php
@@ -22,27 +22,9 @@ use Symfony\Component\DependencyInjection\Reference;
 
 abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
 {
-    /** @group legacy */
-    public function testLegacyLoadWithSeveralHandlers()
-    {
-        if (class_exists(SwitchUserTokenProcessor::class)) {
-            $this->markTestSkipped('Symfony MonologBridge < 5.2 is needed.');
-        }
-
-        $this->doTestLoadWithSeveralHandlers('ERROR');
-    }
-
     public function testLoadWithSeveralHandlers()
     {
-        if (!class_exists(SwitchUserTokenProcessor::class)) {
-            $this->markTestSkipped('Symfony MonologBridge >= 5.2 is needed.');
-        }
-
-        $this->doTestLoadWithSeveralHandlers(new Definition(ErrorLevelActivationStrategy::class, ['ERROR']));
-    }
-
-    private function doTestLoadWithSeveralHandlers($activation)
-    {
+        $activation = new Definition(ErrorLevelActivationStrategy::class, ['ERROR']);
         $container = $this->getContainer('multiple_handlers');
 
         $this->assertTrue($container->hasDefinition('monolog.logger'));
@@ -70,27 +52,9 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
         $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested2'), ['WARNING', 'ERROR'], 'EMERGENCY', true]);
     }
 
-    /** @group legacy */
-    public function testLegacyLoadWithOverwriting()
-    {
-        if (class_exists(SwitchUserTokenProcessor::class)) {
-            $this->markTestSkipped('Symfony MonologBridge < 5.2 is needed.');
-        }
-
-        $this->doTestLoadWithOverwriting('ERROR');
-    }
-
     public function testLoadWithOverwriting()
     {
-        if (!class_exists(SwitchUserTokenProcessor::class)) {
-            $this->markTestSkipped('Symfony MonologBridge >= 5.2 is needed.');
-        }
-
-        $this->doTestLoadWithOverwriting(new Definition(ErrorLevelActivationStrategy::class, ['ERROR']));
-    }
-
-    private function doTestLoadWithOverwriting($activation)
-    {
+        $activation = new Definition(ErrorLevelActivationStrategy::class, ['ERROR']);
         $container = $this->getContainer('overwriting');
 
         $this->assertTrue($container->hasDefinition('monolog.logger'));
@@ -202,10 +166,6 @@ abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
 
     public function testServerLog()
     {
-        if (!class_exists('Symfony\Bridge\Monolog\Handler\ServerLogHandler')) {
-            $this->markTestSkipped('The ServerLogHandler is not available.');
-        }
-
         $container = $this->getContainer('server_log');
 
         $this->assertEquals([

--- a/Tests/DependencyInjection/MonologExtensionTest.php
+++ b/Tests/DependencyInjection/MonologExtensionTest.php
@@ -544,27 +544,9 @@ class MonologExtensionTest extends DependencyInjectionTest
     }
 
     /** @group legacy */
-    public function testLegacyFingersCrossedHandlerWhenExcluded404sAreSpecified()
-    {
-        if (class_exists(SwitchUserTokenProcessor::class)) {
-            $this->markTestSkipped('Symfony MonologBridge < 5.2 is needed.');
-        }
-
-        $this->doTestFingersCrossedHandlerWhenExcluded404sAreSpecified('WARNING');
-    }
-
-    /** @group legacy */
     public function testFingersCrossedHandlerWhenExcluded404sAreSpecified()
     {
-        if (!class_exists(SwitchUserTokenProcessor::class)) {
-            $this->markTestSkipped('Symfony MonologBridge >= 5.2 is needed.');
-        }
-
-        $this->doTestFingersCrossedHandlerWhenExcluded404sAreSpecified(new Definition(ErrorLevelActivationStrategy::class, ['WARNING']));
-    }
-
-    private function doTestFingersCrossedHandlerWhenExcluded404sAreSpecified($activation)
-    {
+        $activation = new Definition(ErrorLevelActivationStrategy::class, ['WARNING']);
         $container = $this->getContainer([['handlers' => [
             'main' => ['type' => 'fingers_crossed', 'handler' => 'nested', 'excluded_404s' => ['^/foo', '^/bar']],
             'nested' => ['type' => 'stream', 'path' => '/tmp/symfony.log']
@@ -588,30 +570,9 @@ class MonologExtensionTest extends DependencyInjectionTest
         $this->assertDICConstructorArguments($handler, [new Reference('monolog.handler.nested'), new Reference('monolog.handler.main.not_found_strategy'), 0, true, true, null]);
     }
 
-    /** @group legacy */
-    public function testLegacyFingersCrossedHandlerWhenExcludedHttpCodesAreSpecified()
-    {
-        if (class_exists(SwitchUserTokenProcessor::class)) {
-            $this->markTestSkipped('Symfony MonologBridge < 5.2 is needed.');
-        }
-
-        $this->doTestFingersCrossedHandlerWhenExcludedHttpCodesAreSpecified('WARNING');
-    }
-
     public function testFingersCrossedHandlerWhenExcludedHttpCodesAreSpecified()
     {
-        if (!class_exists(SwitchUserTokenProcessor::class)) {
-            $this->markTestSkipped('Symfony MonologBridge >= 5.2 is needed.');
-        }
-
-        $this->doTestFingersCrossedHandlerWhenExcludedHttpCodesAreSpecified(new Definition(ErrorLevelActivationStrategy::class, ['WARNING']));
-    }
-
-    private function doTestFingersCrossedHandlerWhenExcludedHttpCodesAreSpecified($activation)
-    {
-        if (!class_exists('Symfony\Bridge\Monolog\Handler\FingersCrossed\HttpCodeActivationStrategy')) {
-            $this->markTestSkipped('Symfony Monolog 4.1+ is needed.');
-        }
+        $activation = new Definition(ErrorLevelActivationStrategy::class, ['WARNING']);
 
         $container = $this->getContainer([['handlers' => [
             'main' => [
@@ -649,10 +610,9 @@ class MonologExtensionTest extends DependencyInjectionTest
     }
 
     /**
-     * @param array $handlerOptions
      * @dataProvider v2RemovedDataProvider
      */
-    public function testV2Removed($handlerOptions)
+    public function testV2Removed(array $handlerOptions)
     {
         if (Logger::API === 1) {
             $this->markTestSkipped('Not valid for V1');
@@ -669,7 +629,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         $loader->load([['handlers' => ['main' => $handlerOptions]]], $container);
     }
 
-    public function v2RemovedDataProvider()
+    public function v2RemovedDataProvider(): array
     {
         return [
             [['type' => 'hipchat', 'token' => 'abc123', 'room' => 'foo']],
@@ -679,10 +639,9 @@ class MonologExtensionTest extends DependencyInjectionTest
     }
 
     /**
-     * @param string $handlerType
      * @dataProvider v1AddedDataProvider
      */
-    public function testV2AddedOnV1($handlerType)
+    public function testV2AddedOnV1(string $handlerType)
     {
         if (Logger::API !== 1) {
             $this->markTestSkipped('Only valid on Monolog V1');
@@ -701,7 +660,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         $loader->load([['handlers' => ['main' => ['type' => $handlerType]]]], $container);
     }
 
-    public function v1AddedDataProvider()
+    public function v1AddedDataProvider(): array
     {
         return [
             ['fallbackgroup'],
@@ -726,7 +685,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         $this->assertDICConstructorArguments($definition, $expectedArgs);
     }
 
-    public function provideLoglevelParameterConfig()
+    public function provideLoglevelParameterConfig(): array
     {
         return [
             'browser console with parameter level' => [
@@ -878,7 +837,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         ], $container->getDefinition(FooProcessorWithPriority::class)->getTag('monolog.processor'));
     }
 
-    protected function getContainer(array $config = [], array $thirdPartyDefinitions = [])
+    protected function getContainer(array $config = [], array $thirdPartyDefinitions = []): ContainerBuilder
     {
         $container = new ContainerBuilder(new EnvPlaceholderParameterBag());
         foreach ($thirdPartyDefinitions as $id => $definition) {

--- a/composer.json
+++ b/composer.json
@@ -16,17 +16,17 @@
         }
     ],
     "require": {
-        "php": ">=7.1.3",
-        "symfony/monolog-bridge": "~4.4 || ^5.0 || ^6.0 || ^7.0",
-        "symfony/dependency-injection": "^4.4 || ^5.0 || ^6.0 || ^7.0",
-        "symfony/config": "~4.4 || ^5.0 || ^6.0 || ^7.0",
-        "symfony/http-kernel": "~4.4 || ^5.0 || ^6.0 || ^7.0",
-        "monolog/monolog": "^1.22 || ^2.0 || ^3.0"
+        "php": ">=7.2.5",
+        "symfony/monolog-bridge": "^5.4 || ^6.0 || ^7.0",
+        "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
+        "symfony/config": "^5.4 || ^6.0 || ^7.0",
+        "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0",
+        "monolog/monolog": "^1.25.1 || ^2.0 || ^3.0"
     },
     "require-dev": {
-        "symfony/yaml": "~4.4 || ^5.0 || ^6.0 || ^7.0",
-        "symfony/console": "~4.4 || ^5.0 || ^6.0 || ^7.0",
-        "symfony/phpunit-bridge": "^5.2 || ^6.0 || ^7.0"
+        "symfony/yaml": "^5.4 || ^6.0 || ^7.0",
+        "symfony/console": "^5.4 || ^6.0 || ^7.0",
+        "symfony/phpunit-bridge": "^6.3 || ^7.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bundle\\MonologBundle\\": "" },


### PR DESCRIPTION
This PR drops support for Symfony 4 and unmaintained Symfony 5 branches. This allows us to throw out obsolete compatibility code for unmaintained Symfony releases.