### PR TITLE
Add support for the `#[WithMonologChannel]` attribute of Monolog 3.5 to autoconfigure the channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Add support for the `WithMonologChannel` attribute of Monolog 3.5.0 to autoconfigure the `monolog.logger` tag
 * Add support for Symfony 7
 * Remove support for Symfony 4
 * Add support for env placeholders in the `level` option of handlers

--- a/DependencyInjection/MonologExtension.php
+++ b/DependencyInjection/MonologExtension.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\MonologBundle\DependencyInjection;
 
 use Monolog\Attribute\AsMonologProcessor;
+use Monolog\Attribute\WithMonologChannel;
 use Monolog\Handler\FingersCrossed\ErrorLevelActivationStrategy;
 use Monolog\Handler\HandlerInterface;
 use Monolog\Logger;
@@ -134,6 +135,9 @@ class MonologExtension extends Extension
                 }
 
                 $definition->addTag('monolog.processor', $tagAttributes);
+            });
+            $container->registerAttributeForAutoconfiguration(WithMonologChannel::class, static function (ChildDefinition $definition, WithMonologChannel $attribute): void {
+                $definition->addTag('monolog.logger', ['channel' => $attribute->channel]);
             });
         }
     }

--- a/Tests/DependencyInjection/Fixtures/ServiceWithChannel.php
+++ b/Tests/DependencyInjection/Fixtures/ServiceWithChannel.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Fixtures;
+
+use Monolog\Attribute\WithMonologChannel;
+
+#[WithMonologChannel('fixture')]
+class ServiceWithChannel
+{
+}

--- a/Tests/DependencyInjection/MonologExtensionTest.php
+++ b/Tests/DependencyInjection/MonologExtensionTest.php
@@ -13,16 +13,17 @@ namespace Symfony\Bundle\MonologBundle\Tests\DependencyInjection;
 
 use InvalidArgumentException;
 use Monolog\Attribute\AsMonologProcessor;
+use Monolog\Attribute\WithMonologChannel;
 use Monolog\Handler\FingersCrossed\ErrorLevelActivationStrategy;
 use Monolog\Handler\RollbarHandler;
 use Monolog\Logger;
 use Monolog\Processor\UidProcessor;
-use Symfony\Bridge\Monolog\Processor\SwitchUserTokenProcessor;
 use Symfony\Bundle\MonologBundle\DependencyInjection\MonologExtension;
 use Symfony\Bundle\MonologBundle\DependencyInjection\Compiler\LoggerChannelPass;
 use Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Fixtures\AsMonologProcessor\FooProcessor;
 use Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Fixtures\AsMonologProcessor\FooProcessorWithPriority;
 use Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Fixtures\AsMonologProcessor\RedeclareMethodProcessor;
+use Symfony\Bundle\MonologBundle\Tests\DependencyInjection\Fixtures\ServiceWithChannel;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag;
@@ -835,6 +836,26 @@ class MonologExtensionTest extends DependencyInjectionTest
                 'priority' => 10,
             ],
         ], $container->getDefinition(FooProcessorWithPriority::class)->getTag('monolog.processor'));
+    }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testWithLoggerChannelAutoconfiguration(): void
+    {
+        if (!class_exists(WithMonologChannel::class)) {
+            $this->markTestSkipped('Monolog >= 3.5.0 is needed.');
+        }
+
+        $container = $this->getContainer([], [
+            ServiceWithChannel::class => (new Definition(ServiceWithChannel::class))->setAutoconfigured(true),
+        ]);
+
+        $this->assertSame([
+            [
+                'channel' => 'fixture',
+            ],
+        ], $container->getDefinition(ServiceWithChannel::class)->getTag('monolog.logger'));
     }
 
     protected function getContainer(array $config = [], array $thirdPartyDefinitions = []): ContainerBuilder


### PR DESCRIPTION
Configuring custom channels on some services is one of the last reasons I have for defining services explicitly in my config files. This attribute allows to solve that.