### PR TITLE
Fix compatibility with PHPUnit 11

### DIFF
--- a/Tests/DependencyInjection/Compiler/AddSwiftMailerTransportPassTest.php
+++ b/Tests/DependencyInjection/Compiler/AddSwiftMailerTransportPassTest.php
@@ -28,10 +28,7 @@ class AddSwiftMailerTransportPassTest extends TestCase
 
     private $definition;
 
-    /**
-     * @before
-     */
-    protected function doSetUp()
+    protected function setUp(): void
     {
         $this->compilerPass = new AddSwiftMailerTransportPass();
         $this->definition = new Definition(null, [new Reference('swiftmailer')]);

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -42,7 +42,7 @@ class ConfigurationTest extends TestCase
         $this->assertFalse($config['handlers']['foobar']['nested']);
     }
 
-    public function provideProcessStringChannels()
+    public static function provideProcessStringChannels(): array
     {
         return [
             ['foo', 'foo', true],
@@ -74,7 +74,7 @@ class ConfigurationTest extends TestCase
         $this->assertEquals($expectedString, $config['handlers']['foobar']['channels']['elements'][0]);
     }
 
-    public function provideGelfPublisher()
+    public static function provideGelfPublisher(): array
     {
         return [
             [
@@ -532,7 +532,7 @@ class ConfigurationTest extends TestCase
         $this->assertEquals($processedConfiguration, $config['handlers']['main']['process_psr_3_messages']);
     }
 
-    public function processPsr3MessagesProvider(): iterable
+    public static function processPsr3MessagesProvider(): iterable
     {
         yield 'Not specified' => [[], ['enabled' => null]];
 

--- a/Tests/DependencyInjection/DependencyInjectionTestCase.php
+++ b/Tests/DependencyInjection/DependencyInjectionTestCase.php
@@ -13,7 +13,7 @@ namespace Symfony\Bundle\MonologBundle\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
 
-abstract class DependencyInjectionTest extends TestCase
+abstract class DependencyInjectionTestCase extends TestCase
 {
     /**
      * Assertion on the Class of a DIC Service Definition.

--- a/Tests/DependencyInjection/FixtureMonologExtensionTestCase.php
+++ b/Tests/DependencyInjection/FixtureMonologExtensionTestCase.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
-abstract class FixtureMonologExtensionTest extends DependencyInjectionTest
+abstract class FixtureMonologExtensionTestCase extends DependencyInjectionTestCase
 {
     public function testLoadWithSeveralHandlers()
     {

--- a/Tests/DependencyInjection/MonologExtensionTest.php
+++ b/Tests/DependencyInjection/MonologExtensionTest.php
@@ -30,7 +30,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBa
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-class MonologExtensionTest extends DependencyInjectionTest
+class MonologExtensionTest extends DependencyInjectionTestCase
 {
     public function testLoadWithDefault()
     {
@@ -628,7 +628,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         $loader->load([['handlers' => ['main' => $handlerOptions]]], $container);
     }
 
-    public function v2RemovedDataProvider(): array
+    public static function v2RemovedDataProvider(): array
     {
         return [
             [['type' => 'hipchat', 'token' => 'abc123', 'room' => 'foo']],
@@ -637,33 +637,19 @@ class MonologExtensionTest extends DependencyInjectionTest
         ];
     }
 
-    /**
-     * @dataProvider v1AddedDataProvider
-     */
-    public function testV2AddedOnV1(string $handlerType)
+    public function testV2AddedOnV1()
     {
         if (Logger::API !== 1) {
             $this->markTestSkipped('Only valid on Monolog V1');
-
-            return;
         }
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            \sprintf('"%s" was added in Monolog v2, please upgrade if you wish to use it.', $handlerType)
-        );
+        $this->expectExceptionMessage('"fallbackgroup" was added in Monolog v2, please upgrade if you wish to use it.');
 
         $container = new ContainerBuilder();
         $loader = new MonologExtension();
 
-        $loader->load([['handlers' => ['main' => ['type' => $handlerType]]]], $container);
-    }
-
-    public function v1AddedDataProvider(): array
-    {
-        return [
-            ['fallbackgroup'],
-        ];
+        $loader->load([['handlers' => ['main' => ['type' => 'fallbackgroup']]]], $container);
     }
 
     /**
@@ -684,7 +670,7 @@ class MonologExtensionTest extends DependencyInjectionTest
         $this->assertDICConstructorArguments($definition, $expectedArgs);
     }
 
-    public function provideLoglevelParameterConfig(): array
+    public static function provideLoglevelParameterConfig(): array
     {
         return [
             'browser console with parameter level' => [

--- a/Tests/DependencyInjection/XmlMonologExtensionTest.php
+++ b/Tests/DependencyInjection/XmlMonologExtensionTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
-class XmlMonologExtensionTest extends FixtureMonologExtensionTest
+class XmlMonologExtensionTest extends FixtureMonologExtensionTestCase
 {
     protected function loadFixture(ContainerBuilder $container, $fixture)
     {

--- a/Tests/DependencyInjection/YamlMonologExtensionTest.php
+++ b/Tests/DependencyInjection/YamlMonologExtensionTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
-class YamlMonologExtensionTest extends FixtureMonologExtensionTest
+class YamlMonologExtensionTest extends FixtureMonologExtensionTestCase
 {
     protected function loadFixture(ContainerBuilder $container, $fixture)
     {


### PR DESCRIPTION
This PR fixes a couple of compatibility issues with PHPUnit 11:

* Data provider methods must be static.
* The mock builder does not have a `setMethods()` method anymore.
* Abstract test classes must not use the suffix `Test`.

Note: The tests are still run with PHPUnit 8.5 and 9.6 though. The PR merely enables us to use PHPUnit 11 in the future.