### PR TITLE
Fix test with `symfony/config:^7.2`

### DIFF
--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\MonologBundle\Tests\DependencyInjection;
 
+use Composer\InstalledVersions;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\MonologBundle\DependencyInjection\Configuration;
@@ -534,7 +535,13 @@ class ConfigurationTest extends TestCase
     public function processPsr3MessagesProvider(): iterable
     {
         yield 'Not specified' => [[], ['enabled' => null]];
-        yield 'Null' => [['process_psr_3_messages' => null], ['enabled' => true]];
+
+        if (version_compare(InstalledVersions::getVersion('symfony/config'), '7.2', '>=')) {
+            yield 'Null' => [['process_psr_3_messages' => null], ['enabled' => null]];
+        } else {
+            yield 'Null' => [['process_psr_3_messages' => null], ['enabled' => true]];
+        }
+
         yield 'True' => [['process_psr_3_messages' => true], ['enabled' => true]];
         yield 'False' => [['process_psr_3_messages' => false], ['enabled' => false]];
 


### PR DESCRIPTION
Following https://github.com/symfony/symfony/pull/58490#issuecomment-2453496578. Until the Symfony PR, null wasn't supported in boolean nodes and defaulted to true.